### PR TITLE
fix missing recipe name without command (eg. `tn ipad`)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -86,7 +86,7 @@ if (args[0] !== '-h' && args[0] !== '--help' && args[0] !== 'help') {
   else {
 
     // prepend build
-    args.unshift('build');
+    args.unshift('build',cmd);
 
     // execute ti
     child_process.spawn('ti', args, {


### PR DESCRIPTION
Today I try to use tn! It's very useful. Thanks.

And I found a bug :)
Running `tn` without command doesn't work. `tn ipad`
