### PR TITLE
closes #34

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -63,18 +63,32 @@ function generate() {
 
   logger.info('Looking up connected devices, emulators and simulators..');
 
-  child_process.exec('ti info -o json', {
-    maxBuffer: 1024 * 1024
-  }, function(error, stdout, stderr) {
+  var info_command = spawn('ti', ['info', '-o', 'json']);
+  var info_string = "";
+  var info_error = false;
+  info_command.stdout.on('data', function(data) {
+    info_string += data.toString();
+  });
+  info_command.stderr.on('data', function(data) {
+    logger.error(data);
+  });
+  info_command.on('close', function(code) {
+    process(code, info_string);
+  });
+  info_command.on('error', function(err) {
+      logger.error('Failed to read Titanium info: ' + JSON.stringify(err));
+  });
 
-    if (error) {
+  function process(code, string) {
+
+    if (code !== 0) {
       logger.error('Failed to read Titanium info: ' + error);
 
     } else {
 
       console.log();
 
-      var config = JSON.parse(stdout);
+      var config = JSON.parse(string);
 
       if (config.android.emulators && config.android.emulators.length > 0) {
 
@@ -149,7 +163,7 @@ function generate() {
       logger.info('Done');
     }
 
-  });
+  };
 }
 
 function spawn(cmd, args, opts) {


### PR DESCRIPTION
You need to be using `spawn` instead of `exec` otherwise you can get `maxBuffer exceeded` issues for large `ti info` outputs.
