### PR TITLE
Made it possible to force TiNy to use $appc ti

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -179,6 +179,8 @@ function displayHelp() {
   console.log('  -h, --help, help'.cyan + '\t\t' + 'displays help');
   console.log('  -v, --version, version'.cyan + '\t' + 'displays the current version');
   console.log('  --verbose'.cyan + '\t\t\t' + 'shows what\'s cooking and confirm or save the recipe');
+  console.log('  --prefer-appc'.cyan + '\t\t\t' + 'forces TiNy to run the recipe with $ appc [...]');
+  console.log('  --prefer-ti'.cyan + '\t\t\t' + 'forces TiNy to run the recipe with $ ti [...]');
   console.log();
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -129,6 +129,10 @@ else if (cmd === '-v' || cmd === '--version' || cmd === 'version') {
       }
 
     } catch (e) {}
+    
+    if (process.argv.indexOf('--appc') > 0) {
+        opts.preferAppc = true;
+    }
 
     // Show what TiNy made (only for build and create, not to mess with JSON output)
     console.log('TiNy'.cyan.bold + ' cooked: ' + ('[appc] ti ' + utils.join(args)).yellow + '\n');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -115,23 +115,27 @@ else if (cmd === '-v' || cmd === '--version' || cmd === 'version') {
     var opts = {
       stdio: 'inherit'
     };
-
-    // try to detect if project is platform
-    try {
-
-      var tiapp = fs.readFileSync(path.join(process.cwd(), 'tiapp.xml'), {
-        encoding: 'utf-8'
-      });
-
-      // platform
-      if (tiapp.indexOf('appc-app-id') !== -1) {
-        opts.preferAppc = true;
-      }
-
-    } catch (e) {}
     
-    if (process.argv.indexOf('--appc') > 0) {
+    if (process.argv.indexOf('--prefer-appc') !== -1) {
         opts.preferAppc = true;
+    }
+    else if (process.argv.indexOf('--prefer-ti') !== -1) {
+        opts.preferAppc = false;
+    }
+    else {
+      // try to detect if project is platform
+      try {
+
+        var tiapp = fs.readFileSync(path.join(process.cwd(), 'tiapp.xml'), {
+          encoding: 'utf-8'
+        });
+
+        // platform
+        if (tiapp.indexOf('appc-app-id') !== -1) {
+          opts.preferAppc = true;
+        }
+
+      } catch (e) {}
     }
 
     // Show what TiNy made (only for build and create, not to mess with JSON output)


### PR DESCRIPTION
In some cases, I prefer to use only $ti - but to force TiNy to use $appc ti - we now can set the preferAppc to true by adding "--appc"