### PR TITLE
feat: Add macOS support - Catalyst development & Mac App Store distribution (v5.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2025-01-10
+
+### Added
+
+- **macOS Support**: Added built-in recipes for building iOS apps for macOS using Mac Catalyst
+  - `mac`: Build for macOS (`--platform ios --target macos`)
+  - `catalyst`: Alias for `--mac`
+  - Requires Titanium SDK 13.1.0+ with macOS build support
+  - Works on Apple Silicon Macs running macOS apps via Catalyst
+
+### Usage Examples
+
+```bash
+# Build for macOS using Mac Catalyst
+tn mac
+
+# Using the catalyst alias
+tn catalyst
+
+# Combine with other recipes
+tn mac --verbose
+```
+
 ## [5.0.0] - 2025-08-31
 
 ### 🚀 Major Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - 2026-02-05
+
+### Added
+
+- **Mac App Store Distribution**: Added built-in recipe for building Mac Catalyst apps for Mac App Store
+  - `macstore`: Build for Mac App Store (`--ios --target dist-macappstore`)
+  - Requires **Titanium SDK 13.1.1.GA**+ with Mac App Store distribution support (officially included)
+  - Creates `.xcarchive` ready for upload via Xcode Organizer
+  - Automatically detects installed Mac App Store Distribution certificates
+  - No interactive prompts required when certificates are properly configured
+
+### Usage Examples
+
+```bash
+# Build for Mac App Store distribution
+tn macstore
+
+# Combine with other recipes
+tn macstore --verbose
+```
+
+### Compatibility
+
+This release complements the Mac Catalyst support introduced in v5.1.0 and requires the official Mac App Store distribution target (`dist-macappstore`) that was added to Titanium SDK 13.1.1.GA.
+
 ## [5.1.0] - 2025-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ TiNy includes comprehensive built-in recipes for modern mobile development. All 
 | universal         | --device-family universal                              |
 | uni               | --universal                                            |
 | watch             | --ios --launch-watch-app                               |
+| mac               | --platform ios --target macos                          |
+| catalyst          | --mac                                                  |
 | appstore          | --ios --target dist-appstore                           |
 | as                | --appstore                                             |
 | playstore         | --android --target dist-playstore                      |

--- a/README.md
+++ b/README.md
@@ -107,23 +107,16 @@ TiNy includes comprehensive built-in recipes for modern mobile development. All 
 | ioses             | --ios --device --device-id all                         |
 | droid             | --android --device                                     |
 | desktop           | -output-dir ~/Desktop                                  |
-| ip17              | --sim-version 17.0 --sim-type iphone                   |
-| ip18              | --sim-version 18.0 --sim-type iphone                   |
-| ipad17            | --sim-version 17.0 --sim-type ipad                     |
-| ipad18            | --sim-version 18.0 --sim-type ipad                     |
+| ip18              | --sim-version 18.6 --sim-type iphone                   |
+| ip26              | --sim-version 26.1 --sim-type iphone                   |
+| ipad18            | --sim-version 18.6 --sim-type ipad                     |
+| ipad26            | --sim-version 26.1 --sim-type ipad                     |
 | key-password      | --key-password %s --key-password %s --platform android |
 | android-sdk       | --android-sdk %s --platform android                    |
 | avd-abi           | --avd-abi %s --platform android                        |
 | keystore          | --keystore %s --platform android                       |
 | alias             | --alias %s --platform android                          |
 | store-password    | --store-password %s --platform android                 |
-| avd-skin          | --avd-skin %s --platform android                       |
-| force-copy        | --force-copy --platform ios                            |
-| force-copy-all    | --force-copy-all --platform ios                        |
-| retina            | --retina --platform ios                                |
-| sim-64bit         | --sim-64bit --platform ios                             |
-| sim-focus         | --sim-focus --platform ios                             |
-| tall              | --tall --retina --platform ios                         |
 | device-family     | --device-family %s --platform ios                      |
 | ios-version       | --ios-version %s --platform ios                        |
 | pp-uuid           | --pp-uuid %s --platform ios                            |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ TiNy includes comprehensive built-in recipes for modern mobile development. All 
 | catalyst          | --mac                                                  |
 | appstore          | --ios --target dist-appstore                           |
 | as                | --appstore                                             |
+| macstore          | --ios --target dist-macappstore                        |
 | playstore         | --android --target dist-playstore                      |
 | play              | --playstore                                            |
 | ps                | --playstore                                            |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "5.1.0",
+  "version": "5.2.0",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "5.0.0",
+  "version": "5.1.0",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"

--- a/tn.json
+++ b/tn.json
@@ -13,6 +13,7 @@
 
 	"appstore": ["--ios", "--target", "dist-appstore"],
 	"as": ["--appstore"],
+	"macstore": ["--ios", "--target", "dist-macappstore"],
 	"playstore": ["--android", "--target", "dist-playstore"],
 	"play": ["--playstore"],
 	"ps": ["--playstore"],

--- a/tn.json
+++ b/tn.json
@@ -8,6 +8,8 @@
 	"universal": ["--device-family", "universal"],
 	"uni": ["--universal"],
 	"watch": ["--ios", "--launch-watch-app"],
+	"mac": ["--platform", "ios", "--target", "macos"],
+	"catalyst": ["--mac"],
 
 	"appstore": ["--ios", "--target", "dist-appstore"],
 	"as": ["--appstore"],

--- a/tn.json
+++ b/tn.json
@@ -26,10 +26,10 @@
 
 	"desktop": ["-output-dir", "~/Desktop"],
 
-	"ip15": ["--sim-version", "17.0", "--sim-type", "iphone"],
-	"ip16": ["--sim-version", "18.0", "--sim-type", "iphone"],
-	"ipad15": ["--sim-version", "17.0", "--sim-type", "ipad"],
-	"ipad16": ["--sim-version", "18.0", "--sim-type", "ipad"],
+	"ip18": ["--sim-version", "18.6", "--sim-type", "iphone"],
+	"ip26": ["--sim-version", "26.1", "--sim-type", "iphone"],
+	"ipad18": ["--sim-version", "18.6", "--sim-type", "ipad"],
+	"ipad26": ["--sim-version", "26.1", "--sim-type", "ipad"],
 
 	"key-password": ["--key-password", "%s", "--key-password", "%s", "--platform", "android"],
 	"android-sdk": ["--android-sdk", "%s", "--platform", "android"],
@@ -37,13 +37,6 @@
 	"keystore": ["--keystore", "%s", "--platform", "android"],
 	"alias": ["--alias", "%s", "--platform", "android"],
 	"store-password": ["--store-password", "%s", "--platform", "android"],
-	"avd-skin": ["--avd-skin", "%s", "--platform", "android"],
-	"force-copy": ["--force-copy", "--platform", "ios"],
-	"force-copy-all": ["--force-copy-all", "--platform", "ios"],
-	"retina": ["--retina", "--platform", "ios"],
-	"sim-64bit": ["--sim-64bit", "--platform", "ios"],
-	"sim-focus": ["--sim-focus", "--platform", "ios"],
-	"tall": ["--tall", "--retina", "--platform", "ios"],
 	"device-family": ["--device-family", "%s", "--platform", "ios"],
 	"ios-version": ["--ios-version", "%s", "--platform", "ios"],
 	"pp-uuid": ["--pp-uuid", "%s", "--platform", "ios"],


### PR DESCRIPTION
# Add macOS support - Catalyst development and Mac App Store distribution

This PR adds two recipes for building Mac Catalyst apps: one for local development and another for Mac App Store distribution.

## New recipes

### Development (v5.1.0)

- `tn mac` - Build for macOS via Catalyst (expands to `ti build --platform ios --target macos`)
- `tn catalyst` - Alias for `mac`

### Distribution (v5.2.0)

- `tn macstore` - Build for Mac App Store (expands to `ti build --platform ios --target dist-macappstore`)

The `macstore` recipe requires Titanium SDK 13.1.1.GA or later. It creates an `.xcarchive` that Xcode Organizer can upload to App Store Connect. If your Mac App Store Distribution certificate is installed, it finds it automatically without prompting.

## Other changes

Updated iOS simulator recipes (ip18/ip26/ipad18/ipad26) and removed some obsolete ones that don't make sense with Titanium SDK 13.

## Testing

```bash
# Development builds
tn mac --verbose
tn catalyst

# Distribution build
tn macstore
```

I've verified all three work correctly with Titanium SDK 13.1.1.GA.

## Background

My PR for Mac Catalyst support in Titanium SDK was merged and released in 13.1.1.GA: https://github.com/tidev/titanium-sdk/pull/14370

This adds the corresponding recipes to TiNy so you can use `tn macstore` instead of typing the full `ti build --platform ios --target dist-macappstore` every time.