### PR TITLE
fix(android): use AVD id for generated emulator recipes

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -50,7 +50,8 @@ function generate() {
               .replace(/\.+/g, '')
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/-$/, '');
-            const recipe = ['--android', '--emulator', '--device-id', dev.name];
+            const emulatorId = dev.id || dev.name;
+            const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
               recipes.save(name, recipe);


### PR DESCRIPTION
## Summary
`tn generate` was writing Android emulator recipes with the emulator display name (`dev.name`) as `--device-id`.

That breaks in some setups. Titanium checks `--device-id` against the emulator id (AVD id), not the display name, so recipes could still trigger the emulator picker.

This fix makes generated recipes use `dev.id` first, with `dev.name` as a fallback for compatibility.

## Why this matters
AVD metadata includes different values:
- `AvdId` (for example `Pixel_8`): the emulator id Titanium expects in `--device-id`
- `avd.ini.displayname` (for example `Pixel 8`): the label shown in Android Studio
- `skin.name` (for example `pixel_8`): the skin name, not the emulator id

If we pass the wrong field, emulator selection can become inconsistent and interactive.

## Changes
- Updated `generate()` in `lib/setup.js`
- Android emulator recipes now use `dev.id || dev.name` for `--device-id`

## Validation
- Regenerated recipes with `tn generate`
- Verified generated Android emulator recipes now include the AVD id
- Verified `tn <emulator-recipe>` runs without prompting for emulator selection

## Scope
This fix only touches `lib/setup.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Android emulator device identification to use device ID when available, otherwise falling back to device name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->