### PR TITLE
feat: grouped tn list, improved tn generate, and README overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 TODO.txt
 npm-debug.log
+.docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2026-03-01
+
+### Added
+
+- `tn list` now groups recipes into 8 labeled categories: iPhone Simulators, iPad Simulators, Android Emulators, iOS Devices, Android Devices, Distribution, Aliases, and General. Within each group, built-in recipes appear before user recipes. The General group is visually sub-clustered by platform (Apple/iOS, Android, parametric, misc) using blank lines.
+- `tn generate` shows `[INFO] All recipes are up to date.` when no new recipes are found.
+
+### Fixed
+
+- `tn generate` no longer creates duplicate `-iosXXX` recipes on repeated runs. Two bugs caused it: the same UDID reported under multiple iOS versions by `ti info`, and simulators that only appear under an older iOS version gaining a new suffix on every subsequent run even when their UDID was unchanged.
+
+### Changed
+
+- `tn generate` output is compact: only newly saved recipes are printed, not every device `ti info` finds.
+- README recipe tables restructured to match the grouped `tn list` output. Aliases now have their own section. All parametric recipes include descriptions.
+
 ## [5.2.0] - 2026-02-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,20 +118,6 @@ The built-in recipes cover the most common build configurations. A few things wo
 | play      | --playstore                       |
 | ps        | --playstore                       |
 
-**iPhone Simulators**
-
-| name | recipe                               |
-| ---- | ------------------------------------ |
-| ip18 | --sim-version 18.6 --sim-type iphone |
-| ip26 | --sim-version 26.1 --sim-type iphone |
-
-**iPad Simulators**
-
-| name   | recipe                             |
-| ------ | ---------------------------------- |
-| ipad18 | --sim-version 18.6 --sim-type ipad |
-| ipad26 | --sim-version 26.1 --sim-type ipad |
-
 **iOS Devices**
 
 | name  | recipe                         |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TiNy is a CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that lets you build iOS and Android apps with fewer keystrokes. It ships with built-in recipes for common build configurations and lets you compose and save your own.
 
-Version 5.0.0 requires Node.js 18+ and targets iOS and Android only.
+Version 5.3.0 requires Node.js 18+ and targets iOS and Android only.
 
 ## Quick Start [![npm](http://img.shields.io/npm/v/tn.png)](https://www.npmjs.org/package/tn)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Colors will show you which recipes are built-in, user and user-overrides.
 
 ### Option recipes
 
-Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
+Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurrences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
 
 ### Built-in recipes
 
@@ -164,14 +164,14 @@ These recipes accept a value that replaces `%s` in the expanded command. Useful 
 
 **Parametric recipes (Android)**
 
-| name           | recipe                                                 | description                                                          |
-| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
-| alias          | --alias %s --platform android                          | Keystore entry alias (the name given when the key was created)       |
-| android-sdk    | --android-sdk %s --platform android                    | Override the path to the Android SDK installation                    |
-| avd-abi        | --avd-abi %s --platform android                        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
-| key-password   | --key-password %s --key-password %s --platform android | Password for the signing key inside the keystore                     |
-| keystore       | --keystore %s --platform android                       | Path to the `.keystore` file used to sign the APK/AAB                |
-| store-password | --store-password %s --platform android                 | Password for the keystore file itself (distinct from `key-password`) |
+| name           | recipe                                 | description                                                          |
+| -------------- | -------------------------------------- | -------------------------------------------------------------------- |
+| alias          | --alias %s --platform android          | Keystore entry alias (the name given when the key was created)       |
+| android-sdk    | --android-sdk %s --platform android    | Override the path to the Android SDK installation                    |
+| avd-abi        | --avd-abi %s --platform android        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
+| key-password   | --key-password %s --platform android   | Password for the signing key inside the keystore                     |
+| keystore       | --keystore %s --platform android       | Path to the `.keystore` file used to sign the APK/AAB                |
+| store-password | --store-password %s --platform android | Password for the keystore file itself (distinct from `key-password`) |
 
 ### Custom recipes
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TiNy CLI [![Titanium](https://tidev.io/img/tilogo.png)](https://titaniumsdk.com)
+# TiNy CLI
 
-TiNy is a modern CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that allows you to build iOS and Android apps using fewer keystrokes. It has built-in recipes for common build configurations, and allows you to compose and save your own custom recipes.
+TiNy is a CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that lets you build iOS and Android apps with fewer keystrokes. It ships with built-in recipes for common build configurations and lets you compose and save your own.
 
-**Version 5.0.0** is fully modernized for 2025 with enhanced security, Node.js 18+ support, modern dependencies, and focuses exclusively on current mobile platforms (iOS & Android).
+Version 5.0.0 requires Node.js 18+ and targets iOS and Android only.
 
 ## Quick Start [![npm](http://img.shields.io/npm/v/tn.png)](https://www.npmjs.org/package/tn)
 
@@ -70,64 +70,122 @@ Colors will show you which recipes are built-in, user and user-overrides.
 
 ### Option recipes
 
-Most recipes are flags, but a receipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
+Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
 
 ### Built-in recipes
 
-TiNy includes comprehensive built-in recipes for modern mobile development. All recipes support the current Titanium SDK platforms and device types.
+The built-in recipes cover the most common build configurations. A few things worth knowing:
 
-**Recipe Usage:**
+- Recipes expand to full Titanium CLI arguments
+- The first recipe in a command doesn't need the `--` prefix
+- Multiple recipes can be combined in a single command
 
-- Recipes are command-line flags that expand to full Titanium CLI arguments
-- When used as the first argument, recipes don't need the `--` prefix
-- Recipes can be combined and chained for complex build configurations
+**Apple / iOS**
 
-| name              | recipe                                                 |
-| ----------------- | ------------------------------------------------------ |
-| android           | --platform android                                     |
-| ios               | --platform ios                                         |
-| ipad              | --device-family ipad                                   |
-| iphone            | --device-family iphone                                 |
-| ip                | --iphone                                               |
-| universal         | --device-family universal                              |
-| uni               | --universal                                            |
-| watch             | --ios --launch-watch-app                               |
-| mac               | --platform ios --target macos                          |
-| catalyst          | --mac                                                  |
-| appstore          | --ios --target dist-appstore                           |
-| as                | --appstore                                             |
-| macstore          | --ios --target dist-macappstore                        |
-| playstore         | --android --target dist-playstore                      |
-| play              | --playstore                                            |
-| ps                | --playstore                                            |
-| adhoc             | --ios --target dist-adhoc                              |
-| ah                | --adhoc                                                |
-| emulator          | --target emulator                                      |
-| emu               | --emulator                                             |
-| simulator         | --target simulator                                     |
-| sim               | --simulator                                            |
-| device            | --target device                                        |
-| ioses             | --ios --device --device-id all                         |
-| droid             | --android --device                                     |
-| desktop           | -output-dir ~/Desktop                                  |
-| ip18              | --sim-version 18.6 --sim-type iphone                   |
-| ip26              | --sim-version 26.1 --sim-type iphone                   |
-| ipad18            | --sim-version 18.6 --sim-type ipad                     |
-| ipad26            | --sim-version 26.1 --sim-type ipad                     |
-| key-password      | --key-password %s --key-password %s --platform android |
-| android-sdk       | --android-sdk %s --platform android                    |
-| avd-abi           | --avd-abi %s --platform android                        |
-| keystore          | --keystore %s --platform android                       |
-| alias             | --alias %s --platform android                          |
-| store-password    | --store-password %s --platform android                 |
-| device-family     | --device-family %s --platform ios                      |
-| ios-version       | --ios-version %s --platform ios                        |
-| pp-uuid           | --pp-uuid %s --platform ios                            |
-| distribution-name | --distribution-name %s --platform ios                  |
-| sim-version       | --sim-version %s --target simulator --platform ios     |
-| keychain          | --keychain %s --platform ios                           |
-| developer-name    | --developer-name %s --target device --platform ios     |
-| sim-type          | --sim-type %s --target simulator --platform ios        |
+| name      | recipe                        |
+| --------- | ----------------------------- |
+| ios       | --platform ios                |
+| ip        | --iphone                      |
+| ipad      | --device-family ipad          |
+| iphone    | --device-family iphone        |
+| mac       | --platform ios --target macos |
+| catalyst  | --mac                         |
+| sim       | --simulator                   |
+| simulator | --target simulator            |
+| uni       | --universal                   |
+| universal | --device-family universal     |
+| watch     | --ios --launch-watch-app      |
+
+**Android**
+
+| name     | recipe             |
+| -------- | ------------------ |
+| android  | --platform android |
+| droid    | --android --device |
+| emu      | --emulator         |
+| emulator | --target emulator  |
+
+**Distribution**
+
+| name      | recipe                            |
+| --------- | --------------------------------- |
+| appstore  | --ios --target dist-appstore      |
+| as        | --appstore                        |
+| macstore  | --ios --target dist-macappstore   |
+| adhoc     | --ios --target dist-adhoc         |
+| ah        | --adhoc                           |
+| playstore | --android --target dist-playstore |
+| play      | --playstore                       |
+| ps        | --playstore                       |
+
+**iPhone Simulators**
+
+| name | recipe                               |
+| ---- | ------------------------------------ |
+| ip18 | --sim-version 18.6 --sim-type iphone |
+| ip26 | --sim-version 26.1 --sim-type iphone |
+
+**iPad Simulators**
+
+| name   | recipe                             |
+| ------ | ---------------------------------- |
+| ipad18 | --sim-version 18.6 --sim-type ipad |
+| ipad26 | --sim-version 26.1 --sim-type ipad |
+
+**iOS Devices**
+
+| name  | recipe                         |
+| ----- | ------------------------------ |
+| ioses | --ios --device --device-id all |
+
+**Aliases**
+
+Short forms for commonly used recipes. Each alias expands to a single flag that maps to an existing recipe.
+
+| alias    | expands to |
+| -------- | ---------- |
+| ah       | adhoc      |
+| as       | appstore   |
+| catalyst | mac        |
+| emu      | emulator   |
+| ip       | iphone     |
+| play     | playstore  |
+| ps       | playstore  |
+| sim      | simulator  |
+| uni      | universal  |
+
+**Misc**
+
+| name    | recipe                |
+| ------- | --------------------- |
+| desktop | -output-dir ~/Desktop |
+| device  | --target device       |
+
+**Parametric recipes (iOS)**
+
+These recipes accept a value that replaces `%s` in the expanded command. Useful when composing custom recipes with `tn save`.
+
+| name              | recipe                                             | description                                                         |
+| ----------------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| device-family     | --device-family %s --platform ios                  | Target device family: `iphone`, `ipad`, or `universal`              |
+| developer-name    | --developer-name %s --target device --platform ios | Developer certificate name for device builds (e.g. `"John (T3AM)"`) |
+| distribution-name | --distribution-name %s --platform ios              | Distribution certificate name for App Store or Ad Hoc signing       |
+| ios-version       | --ios-version %s --platform ios                    | Target iOS SDK version (e.g. `18.0`)                                |
+| keychain          | --keychain %s --platform ios                       | Path to the macOS keychain file containing signing certificates     |
+| pp-uuid           | --pp-uuid %s --platform ios                        | Provisioning Profile UUID for app signing                           |
+| sim-type          | --sim-type %s --target simulator --platform ios    | Simulator type: `iphone` or `ipad`                                  |
+| sim-version       | --sim-version %s --target simulator --platform ios | iOS version of the simulator to target (e.g. `18.6`)                |
+
+**Parametric recipes (Android)**
+
+| name           | recipe                                                 | description                                                          |
+| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| alias          | --alias %s --platform android                          | Keystore entry alias (the name given when the key was created)       |
+| android-sdk    | --android-sdk %s --platform android                    | Override the path to the Android SDK installation                    |
+| avd-abi        | --avd-abi %s --platform android                        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
+| key-password   | --key-password %s --key-password %s --platform android | Password for the signing key inside the keystore                     |
+| keystore       | --keystore %s --platform android                       | Path to the `.keystore` file used to sign the APK/AAB                |
+| store-password | --store-password %s --platform android                 | Password for the keystore file itself (distinct from `key-password`) |
 
 ### Custom recipes
 
@@ -228,7 +286,7 @@ tn release
 
 ### Resolving aliases
 
-TiNy will convert abbreviations (`-T`) to their full names (`--target`). It needs to this for the next feature.
+TiNy converts abbreviations (`-T`) to their full names (`--target`) to support duplicate resolution.
 
 ### Resolving duplicates
 
@@ -236,32 +294,27 @@ TiNy will resolve any duplicate options and flags in order of appearance.
 
 ## Features
 
-### Modern Architecture (v5.0.0)
+### Changes in v5.0.0
 
-- **Node.js 18+ Support**: Fully compatible with modern Node.js versions
-- **Enhanced Security**: Updated all dependencies to latest secure versions
-- **Modern Dependencies**: Uses lodash, chalk, @inquirer/prompts for better performance
-- **Code Quality**: ESLint 8, Prettier formatting, comprehensive testing setup
+- Requires Node.js 18+ (Titanium CLI needs 20.18.1+)
+- Switched to lodash, chalk, and @inquirer/prompts
+- Dropped support for platforms other than iOS and Android
+- Added ESLint 8 and Prettier
 
-### Device Management
+### Device management
 
-- **Automatic Discovery**: `tn generate` detects all connected iOS simulators and Android emulators
-- **Current Devices**: Supports iPhone 16 series, iPad Air M3, iPad Pro M4, latest Android emulators
-- **Real Device Support**: Works with physical iOS and Android devices
+`tn generate` detects all connected iOS simulators, Android emulators, and physical devices and writes a recipe for each. Supports current hardware including iPhone 16 series, iPad Air M3, iPad Pro M4, and recent Android emulators.
 
-### Recipe System
+### Recipe system
 
-- **Built-in Recipes**: 50+ pre-configured recipes for common build scenarios
-- **Custom Recipes**: Save, edit, and share your own recipe configurations
-- **Project Recipes**: Per-project recipe files for team collaboration
-- **Recipe Chaining**: Combine multiple recipes in a single command
+Ships with 40+ built-in recipes. Save your own with `tn save`, keep per-project recipes in `tn.json`, and chain multiple recipes in a single command.
 
-### Developer Experience
+### Other
 
-- **Interactive Prompts**: Modern CLI prompts for recipe management and execution
-- **Verbose Mode**: Detailed output showing recipe expansion and build process
-- **Safety Features**: Protection against accidental configuration deletion
-- **Modern CLI**: Uses Titanium SDK CLI (`ti`) exclusively
+- `--verbose` shows each expansion step and the final command before running
+- Interactive prompts let you save or cancel before executing
+- Safety checks prevent accidental deletion of recipe files
+- Uses Titanium SDK CLI (`ti`) exclusively
 
 ## Changelog
 

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -45,6 +45,79 @@ function get(name, ingredient) {
   return recipe;
 }
 
+const GROUP_ORDER = [
+  'iPhone Simulators',
+  'iPad Simulators',
+  'Android Emulators',
+  'iOS Devices',
+  'Android Devices',
+  'Distribution',
+  'Aliases',
+  'General'
+];
+
+function generalSubgroup(args) {
+  const argsArr = _.isString(args) ? args.split(' ') : args;
+  const has = (val) => argsArr.includes(val);
+  const argsStr = argsArr.join(' ');
+
+  // Config: parametric recipes with %s
+  if (argsStr.includes('%s')) return 2;
+
+  // Apple/iOS
+  if (argsStr.includes('platform ios') || has('--ios') || has('--iphone') ||
+      has('--mac') || has('--universal') || has('--device-family') ||
+      (has('--target') && has('simulator')) || has('--simulator')) return 0;
+
+  // Android
+  if (argsStr.includes('platform android') || has('--android') ||
+      has('--emulator') || (has('--target') && has('emulator'))) return 1;
+
+  // Misc (device, desktop, etc.)
+  return 3;
+}
+
+function categorizeRecipe(name, args) {
+  const argsArr = _.isString(args) ? args.split(' ') : args;
+  const has = (val) => argsArr.includes(val);
+  const argsStr = argsArr.join(' ');
+
+  // Parametric recipes always go to General
+  if (argsStr.includes('%s')) return 'General';
+
+  // Single-flag alias pointing to another recipe
+  if (argsArr.length === 1 && argsArr[0].startsWith('--') && _.has(recipes_combined, argsArr[0].slice(2))) {
+    return 'Aliases';
+  }
+
+  // Specific simulator with UDID (generated recipes)
+  if (has('--simulator') && has('--device-id')) {
+    return name.startsWith('ipad') ? 'iPad Simulators' : 'iPhone Simulators';
+  }
+
+  // sim-type based (ip18, ip26, ipad18, ipad26)
+  if (has('--sim-type')) {
+    const simType = argsArr[argsArr.indexOf('--sim-type') + 1];
+    return simType === 'ipad' ? 'iPad Simulators' : 'iPhone Simulators';
+  }
+
+  // Specific Android emulator with device-id (generated recipes)
+  if (has('--emulator') && has('--device-id')) return 'Android Emulators';
+
+  // Distribution targets (direct or via alias)
+  if (argsStr.includes('dist-') || has('--appstore') || has('--playstore') || has('--adhoc')) {
+    return 'Distribution';
+  }
+
+  // iOS real devices (ioses)
+  if (has('--ios') && has('--device') && has('--device-id')) return 'iOS Devices';
+
+  // Android real devices
+  if (has('--android') && has('--device') && has('--device-id')) return 'Android Devices';
+
+  return 'General';
+}
+
 function list(forReadMe) {
   if (forReadMe) {
     _.each(recipes_system, function (recipe, name) {
@@ -68,53 +141,85 @@ function list(forReadMe) {
   );
   console.log();
 
-  const recipes = _.keys(recipes_combined).sort();
+  // Build grouped map
+  const grouped = {};
+  GROUP_ORDER.forEach(g => { grouped[g] = []; });
 
-  _.each(recipes, function (recipe) {
+  const systemFirst = (a, b) => {
+    const diff = (_.has(recipes_system, a) ? 0 : 1) - (_.has(recipes_system, b) ? 0 : 1);
+    return diff !== 0 ? diff : a.localeCompare(b);
+  };
+
+  _.each(_.keys(recipes_combined).sort(systemFirst), function (recipe) {
     const args = recipes_combined[recipe];
-    let color;
-
-    if (_.has(recipes_project, recipe)) {
-      color = _.has(recipes_system, recipe) || _.has(recipes_user, recipe) ? 'red' : 'yellow';
-    } else if (_.has(recipes_user, recipe)) {
-      color = _.has(recipes_system, recipe) ? 'blue' : 'cyan';
-    } else {
-      color = 'green';
-    }
-
-    let commands = '';
-
-    if (_.isString(args)) {
-      commands += ' ' + args;
-    } else {
-      commands += utils.join(args);
-    }
-
-    console.log('  ' + recipe + ': ' + chalk[color](commands));
+    const group = categorizeRecipe(recipe, args);
+    grouped[group].push(recipe);
   });
 
-  console.log();
+  // Display each group
+  GROUP_ORDER.forEach(function (group) {
+    const members = grouped[group];
+    if (members.length === 0) return;
+
+    console.log(chalk.bold(group + ':'));
+
+    const isGeneral = group === 'General';
+    const items = isGeneral
+      ? members.slice().sort(function (a, b) {
+          const diff = generalSubgroup(recipes_combined[a]) - generalSubgroup(recipes_combined[b]);
+          return diff !== 0 ? diff : systemFirst(a, b);
+        })
+      : members;
+
+    let lastSubgroup = null;
+
+    items.forEach(function (recipe) {
+      const args = recipes_combined[recipe];
+      let color;
+
+      if (_.has(recipes_project, recipe)) {
+        color = _.has(recipes_system, recipe) || _.has(recipes_user, recipe) ? 'red' : 'yellow';
+      } else if (_.has(recipes_user, recipe)) {
+        color = _.has(recipes_system, recipe) ? 'blue' : 'cyan';
+      } else {
+        color = 'green';
+      }
+
+      if (isGeneral) {
+        const sg = generalSubgroup(args);
+        if (lastSubgroup !== null && sg !== lastSubgroup) console.log();
+        lastSubgroup = sg;
+      }
+
+      let commands = _.isString(args) ? ' ' + args : utils.join(args);
+      console.log('  ' + recipe + ': ' + chalk[color](commands));
+    });
+
+    console.log();
+  });
 }
 
-function save(recipe, args, location) {
+function save(recipe, args, location, silent) {
   if (!validateRecipeName(recipe)) {
     return;
   }
 
   location = location || 'user';
 
-  if (location == 'project' && _.has(recipes_project, recipe)) {
-    logger.info('Changed existing project recipe');
-  } else if (location == 'user' && _.has(recipes_user, recipe)) {
-    logger.info('Changed existing user recipe');
-  } else if (location == 'project' && _.has(recipes_user, recipe)) {
-    logger.info('Saved project recipe, overriding user');
-  } else if (location === 'project' && _.has(recipes_system, recipe)) {
-    logger.info('Saved project recipe, overriding built-in');
-  } else if (location === 'user' && _.has(recipes_system, recipe)) {
-    logger.info('Saved user recipe, overriding built-in');
-  } else {
-    logger.info('Saved ' + location + ' recipe');
+  if (!silent) {
+    if (location == 'project' && _.has(recipes_project, recipe)) {
+      logger.info('Changed existing project recipe');
+    } else if (location == 'user' && _.has(recipes_user, recipe)) {
+      logger.info('Changed existing user recipe');
+    } else if (location == 'project' && _.has(recipes_user, recipe)) {
+      logger.info('Saved project recipe, overriding user');
+    } else if (location === 'project' && _.has(recipes_system, recipe)) {
+      logger.info('Saved project recipe, overriding built-in');
+    } else if (location === 'user' && _.has(recipes_system, recipe)) {
+      logger.info('Saved user recipe, overriding built-in');
+    } else {
+      logger.info('Saved ' + location + ' recipe');
+    }
   }
 
   if (location == 'project') {
@@ -135,10 +240,13 @@ function save(recipe, args, location) {
     clr = 'green';
   }
 
-  console.log();
-  console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+  if (!silent) {
+    console.log();
+    console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+    console.log();
+  }
 
-  console.log();
+  return { recipe, args, clr };
 }
 
 function remove(recipe, location) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,7 +4,9 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const logger = require('./logger'),
-  recipes = require('./recipes');
+  recipes = require('./recipes'),
+  utils = require('./utils'),
+  chalk = require('chalk');
 
 exports.uninstall = uninstall;
 exports.generate = generate;
@@ -41,6 +43,8 @@ function generate() {
       console.log();
 
       const config = JSON.parse(stdout);
+      const saved = [];
+      const savedIds = new Set();
 
       if (config.android) {
         if (config.android.emulators && config.android.emulators.length > 0) {
@@ -54,7 +58,7 @@ function generate() {
             const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -69,7 +73,7 @@ function generate() {
             const recipe = ['--android', '--device', '--device-id', dev.id];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -90,7 +94,7 @@ function generate() {
             const recipe = ['--ios', '--device', '--device-id', dev.udid];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -114,6 +118,8 @@ function generate() {
 
           versions.forEach(function forEach(version) {
             iosSims[version].forEach(function forEach(dev) {
+              if (savedIds.has(dev.udid)) return;
+
               let name = dev.name
                 .toLowerCase()
                 .replace(/[^a-z0-9]+/g, '-')
@@ -121,15 +127,29 @@ function generate() {
               const recipe = ['--ios', '--simulator', '--device-id', dev.udid];
 
               if (recipes.has(name) && versions[0] !== version) {
-                name = name + '-ios' + version.replace(/\./, '');
+                const existing = recipes.get(name);
+                const existingId = existing[existing.indexOf('--device-id') + 1];
+                if (existingId !== dev.udid) {
+                  name = name + '-ios' + version.replace(/\./, '');
+                }
               }
 
               if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-                recipes.save(name, recipe);
+                saved.push(recipes.save(name, recipe, 'user', true));
               }
+              savedIds.add(dev.udid);
             });
           });
         }
+      }
+
+      if (saved.length === 0) {
+        logger.info('All recipes are up to date.');
+      } else {
+        saved.forEach(({ recipe, args, clr }) => {
+          console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+        });
+        console.log();
       }
 
       logger.info('Done');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -50,7 +50,8 @@ function generate() {
               .replace(/\.+/g, '')
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/-$/, '');
-            const recipe = ['--android', '--emulator', '--device-id', dev.name];
+            const emulatorId = dev.id || dev.name;
+            const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
               recipes.save(name, recipe);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "5.2.0",
+  "version": "5.3.0",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"

--- a/tn.json
+++ b/tn.json
@@ -29,7 +29,7 @@
 
 	"desktop": ["-output-dir", "~/Desktop"],
 
-	"key-password": ["--key-password", "%s", "--key-password", "%s", "--platform", "android"],
+	"key-password": ["--key-password", "%s", "--platform", "android"],
 	"android-sdk": ["--android-sdk", "%s", "--platform", "android"],
 	"avd-abi": ["--avd-abi", "%s", "--platform", "android"],
 	"keystore": ["--keystore", "%s", "--platform", "android"],

--- a/tn.json
+++ b/tn.json
@@ -29,11 +29,6 @@
 
 	"desktop": ["-output-dir", "~/Desktop"],
 
-	"ip18": ["--sim-version", "18.6", "--sim-type", "iphone"],
-	"ip26": ["--sim-version", "26.1", "--sim-type", "iphone"],
-	"ipad18": ["--sim-version", "18.6", "--sim-type", "ipad"],
-	"ipad26": ["--sim-version", "26.1", "--sim-type", "ipad"],
-
 	"key-password": ["--key-password", "%s", "--key-password", "%s", "--platform", "android"],
 	"android-sdk": ["--android-sdk", "%s", "--platform", "android"],
 	"avd-abi": ["--avd-abi", "%s", "--platform", "android"],


### PR DESCRIPTION
## Summary

Three things changed: `tn list` now groups recipes by category, `tn generate` no longer creates duplicates on repeated runs, and the README was rewritten to match.

## Changes

### `tn list` — grouped output

Recipes are now organized into 8 labeled groups:

- iPhone Simulators
- iPad Simulators
- Android Emulators
- iOS Devices
- Android Devices
- Distribution
- Aliases
- General

Within each group, built-in recipes come first. The General group is visually sub-clustered by platform (Apple/iOS → Android → parametric → misc) using blank lines between clusters.

### `tn generate` — duplicate fix

This one has been broken for a long time. Running `tn generate` a second time would create new duplicate recipes.

The root cause: Xcode (via `ti info`) reports the same simulator under multiple iOS versions.

Two fixes:

1. A `savedIds` Set tracks processed UDIDs within a run and skips re-processing if the same UDID appears under a second iOS version.

2. Before appending a suffix to resolve a name collision, the code now checks if the existing recipe already points to the same UDID. If it does, no suffix is added.

Output is also cleaner: `tn generate` only prints newly saved recipes, and shows `[INFO] All recipes are up to date.` when nothing changed.

### README

Recipe tables now match the grouped `tn list` output. Aliases have their own section. All parametric recipes have descriptions.

### Remove version-pinned simulator built-ins

Removed `ip18`, `ip26`, `ipad18`, `ipad26` from built-in recipes.

These used `--sim-version` + `--sim-type` without a `--device-id`, which caused Titanium to fall back to the default simulator (most recent) when the specified iOS version wasn't found on the machine. Users should use `tn generate` to create reliable device-specific recipes with `--device-id` (UDID) instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grouped recipe listing for easier navigation.
  * `tn generate` now shows a clear "All recipes are up to date." message.

* **Bug Fixes**
  * Fixed duplicate recipe generation across runs.
  * Corrected Android emulator selection to use the proper device identifier.

* **Documentation**
  * Added comprehensive new docs and updated README, changelog, and guides.

* **Changes**
  * Improved recipe-generation output formatting.
  * Removed several pre-defined simulator presets.
* **Chores**
  * Bumped package version to 5.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->