### PR TITLE
v5.4.0: tn clean, ghost simulator fixes, grouped tn list, and robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 TODO.txt
 npm-debug.log
+.docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2026-03-01
+
+### Added
+
+- `tn list` now groups recipes into 8 labeled categories: iPhone Simulators, iPad Simulators, Android Emulators, iOS Devices, Android Devices, Distribution, Aliases, and General. Within each group, built-in recipes appear before user recipes. The General group is visually sub-clustered by platform (Apple/iOS, Android, parametric, misc) using blank lines.
+- `tn generate` shows `[INFO] All recipes are up to date.` when no new recipes are found.
+
+### Fixed
+
+- `tn generate` no longer creates duplicate `-iosXXX` recipes on repeated runs. Two bugs caused it: the same UDID reported under multiple iOS versions by `ti info`, and simulators that only appear under an older iOS version gaining a new suffix on every subsequent run even when their UDID was unchanged.
+
+### Changed
+
+- `tn generate` output is compact: only newly saved recipes are printed, not every device `ti info` finds.
+- README recipe tables restructured to match the grouped `tn list` output. Aliases now have their own section. All parametric recipes include descriptions.
+
 ## [5.2.0] - 2026-02-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [5.4.0] - 2026-07-30
+
+### Added
+
+- `tn clean` deletes iOS simulators whose runtime is no longer installed. Xcode leaves these behind when a runtime is uninstalled: they still appear in `simctl list`, can never be booted, and take up disk space indefinitely. The command lists what it found grouped by runtime, reports how much space it frees, and asks before deleting anything.
+- `tn clean --data` erases contents and settings of installed simulators, keeping the simulators themselves. Booted simulators are skipped.
+- `tn clean --runtimes` deletes installed iOS runtimes chosen from a list showing size and last use date, warning when the newest installed runtime is selected. Because deleting a runtime makes its simulators unusable, those are removed in the same run and any recipes left pointing at them are offered for removal.
+- `tn generate` reports leftover simulators when it finds them, pointing at `tn clean`.
+
+### Fixed
+
+- `tn generate` no longer regenerated recipes for simulators whose runtime had been uninstalled and then immediately reported them as orphaned, in a loop that repeated on every run. `ti info` still lists those simulators, so the `simctl` check that was already used to detect orphans is now applied when generating too.
+- `tn generate` no longer offers to remove every recipe of a platform that `ti info` did not report at all (for instance an unconfigured Android SDK). An empty device list now means "nothing installed" only when the platform was actually inspected; otherwise its recipes are left alone.
+- Pressing Ctrl+C at a confirmation prompt exits cleanly instead of printing an `ExitPromptError` stack trace.
+- A malformed `~/.tn.json` or `tn.json` no longer takes down every command with a stack trace. The broken file is reported by name and skipped, so `tn list` still works and can be used to find the problem.
+- `tn generate` reports a clear message when `ti info` returns something that is not JSON, or when the Titanium CLI is not installed, instead of crashing.
+- The `postinstall` script no longer fails with a stack trace when the Titanium CLI is absent.
+- `tn rename` rebuilt its recipe list without project recipes, dropping them until the next run.
+
+### Changed
+
+- Recipe files are written indented instead of on a single line. They are meant to be opened and edited by hand.
+- Informational messages are printed without an `[INFO]` label. When every line carries one it conveys nothing, and it made warnings and errors blend into the output. `[WARN]`, `[ERROR]` and `[DEBUG]` keep theirs and now stand out.
+
 ## [5.3.0] - 2026-03-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ TiNy is a CLI wrapper for Titanium SDK build commands that provides "recipe" sho
 - **`lib/kitchen.js`**: Core recipe processing engine that "cooks" arguments
 - **`lib/recipes.js`**: Recipe management (load, save, list recipes from multiple sources)
 - **`lib/setup.js`**: Handles device/simulator recipe generation and 2.x hook removal
+- **`lib/clean.js`**: `tn clean` — removes ghost simulators, simulator data and runtimes
+- **`lib/simctl.js`**: Wrapper around `xcrun simctl`; every lookup returns null on failure
 - **`lib/utils.js`**: Utility functions for argument processing
 - **`lib/config.js`**: Configuration management
 - **`lib/logger.js`**: Logging utilities
@@ -58,8 +60,10 @@ Recipes can be:
 
 ## Development Notes
 
-- The project uses JSHint for linting (see `.jshintrc`)
-- No test framework is configured
+- Linting is ESLint (`.eslintrc.js`), run with `npm run lint` / `npm run lint:fix`. A stale `.jshintrc` is still in the repo but nothing uses it.
+- Formatting is Prettier: `npm run format` / `npm run format:check`
+- Jest is configured (`npm test`) but no tests have been written yet
 - Uses CommonJS modules (`require`/`exports`)
-- Supports Node.js >=0.8
+- Requires Node.js >=18 (see `engines` in `package.json`)
 - Main binary is executable via `./bin/cli.js`
+- Recipe files are written indented, since users edit them by hand

--- a/README.md
+++ b/README.md
@@ -118,20 +118,6 @@ The built-in recipes cover the most common build configurations. A few things wo
 | play      | --playstore                       |
 | ps        | --playstore                       |
 
-**iPhone Simulators**
-
-| name | recipe                               |
-| ---- | ------------------------------------ |
-| ip18 | --sim-version 18.6 --sim-type iphone |
-| ip26 | --sim-version 26.1 --sim-type iphone |
-
-**iPad Simulators**
-
-| name   | recipe                             |
-| ------ | ---------------------------------- |
-| ipad18 | --sim-version 18.6 --sim-type ipad |
-| ipad26 | --sim-version 26.1 --sim-type ipad |
-
 **iOS Devices**
 
 | name  | recipe                         |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ You can generate user recipes for all connected devices, emulators and simulator
   pixel-8-pro-api-34: --platform android --target emulator --device-id "Pixel 8 Pro API 34"
 ```
 
+If `tn generate` finds user recipes pointing to iOS simulators or Android emulators that are no longer installed (e.g. after uninstalling an iOS Simulator runtime in Xcode), it lists them and asks whether to remove them. Physical device recipes are never touched.
+
 #### Project recipes
 
 Project recipes override both user and built-in recipes. The are stored in the current working directory in a file called `tn.json`. To edit this file instead of the global user file add `project` before the `save`, `rename`, `remove` and `reset` commands:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TiNy is a CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that lets you build iOS and Android apps with fewer keystrokes. It ships with built-in recipes for common build configurations and lets you compose and save your own.
 
-Version 5.3.0 requires Node.js 18+ and targets iOS and Android only.
+Version 5.4.0 requires Node.js 18+ and targets iOS and Android only.
 
 ## Quick Start [![npm](http://img.shields.io/npm/v/tn.png)](https://www.npmjs.org/package/tn)
 
@@ -196,6 +196,34 @@ You can generate user recipes for all connected devices, emulators and simulator
 ```
 
 If `tn generate` finds user recipes pointing to iOS simulators or Android emulators that are no longer installed (e.g. after uninstalling an iOS Simulator runtime in Xcode), it lists them and asks whether to remove them. Physical device recipes are never touched.
+
+##### Cleaning up simulators
+
+Xcode does not clean up after itself. Uninstall an iOS runtime and its simulators stay in `~/Library/Developer/CoreSimulator/Devices` forever: they still show up in `simctl list`, they can never be booted again, and they can easily take tens of gigabytes.
+
+`tn clean` deletes them:
+
+```bash
+tn clean                    # delete simulators whose runtime is gone
+tn clean --data             # erase contents and settings, keep the simulators
+tn clean --runtimes         # delete installed runtimes you pick from a list
+tn clean --data --runtimes  # flags combine
+```
+
+With no flags it only removes the unusable ones, which is always safe. Every operation lists what it found, shows how much disk space it would free, and asks before deleting anything — the prompt defaults to no.
+
+`--data` deletes the apps installed in each simulator and their data, keeping the simulators themselves. Booted simulators are skipped.
+
+`--runtimes` lets you pick which runtimes to delete, with their size and last use date shown, and warns you if you pick the newest one you have. Deleting a runtime makes its simulators unusable, so those are removed in the same run and any recipes left pointing at them are offered for removal.
+
+`tn generate` reports leftover simulators when it finds them, so you know they are there:
+
+```
+[WARN]  11 ghost simulators found — their runtime is no longer installed
+        Run  tn clean  to remove them and free up disk space.
+```
+
+Android emulators are not touched by `tn clean`.
 
 #### Project recipes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TiNy is a CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that lets you build iOS and Android apps with fewer keystrokes. It ships with built-in recipes for common build configurations and lets you compose and save your own.
 
-Version 5.0.0 requires Node.js 18+ and targets iOS and Android only.
+Version 5.3.0 requires Node.js 18+ and targets iOS and Android only.
 
 ## Quick Start [![npm](http://img.shields.io/npm/v/tn.png)](https://www.npmjs.org/package/tn)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Colors will show you which recipes are built-in, user and user-overrides.
 
 ### Option recipes
 
-Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
+Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurrences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
 
 ### Built-in recipes
 
@@ -164,14 +164,14 @@ These recipes accept a value that replaces `%s` in the expanded command. Useful 
 
 **Parametric recipes (Android)**
 
-| name           | recipe                                                 | description                                                          |
-| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
-| alias          | --alias %s --platform android                          | Keystore entry alias (the name given when the key was created)       |
-| android-sdk    | --android-sdk %s --platform android                    | Override the path to the Android SDK installation                    |
-| avd-abi        | --avd-abi %s --platform android                        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
-| key-password   | --key-password %s --key-password %s --platform android | Password for the signing key inside the keystore                     |
-| keystore       | --keystore %s --platform android                       | Path to the `.keystore` file used to sign the APK/AAB                |
-| store-password | --store-password %s --platform android                 | Password for the keystore file itself (distinct from `key-password`) |
+| name           | recipe                                 | description                                                          |
+| -------------- | -------------------------------------- | -------------------------------------------------------------------- |
+| alias          | --alias %s --platform android          | Keystore entry alias (the name given when the key was created)       |
+| android-sdk    | --android-sdk %s --platform android    | Override the path to the Android SDK installation                    |
+| avd-abi        | --avd-abi %s --platform android        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
+| key-password   | --key-password %s --platform android   | Password for the signing key inside the keystore                     |
+| keystore       | --keystore %s --platform android       | Path to the `.keystore` file used to sign the APK/AAB                |
+| store-password | --store-password %s --platform android | Password for the keystore file itself (distinct from `key-password`) |
 
 ### Custom recipes
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TiNy CLI [![Titanium](https://tidev.io/img/tilogo.png)](https://titaniumsdk.com)
+# TiNy CLI
 
-TiNy is a modern CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that allows you to build iOS and Android apps using fewer keystrokes. It has built-in recipes for common build configurations, and allows you to compose and save your own custom recipes.
+TiNy is a CLI wrapper for [Titanium SDK](https://titaniumsdk.com) that lets you build iOS and Android apps with fewer keystrokes. It ships with built-in recipes for common build configurations and lets you compose and save your own.
 
-**Version 5.0.0** is fully modernized for 2025 with enhanced security, Node.js 18+ support, modern dependencies, and focuses exclusively on current mobile platforms (iOS & Android).
+Version 5.0.0 requires Node.js 18+ and targets iOS and Android only.
 
 ## Quick Start [![npm](http://img.shields.io/npm/v/tn.png)](https://www.npmjs.org/package/tn)
 
@@ -70,64 +70,122 @@ Colors will show you which recipes are built-in, user and user-overrides.
 
 ### Option recipes
 
-Most recipes are flags, but a receipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
+Most recipes are flags, but a recipe can also be an option. If a recipe is followed by an argument value, TiNy assumes the recipe to be an option and replace any occurences of `%s` in the recipe with the value. See step 4 of the Quick Start for an example.
 
 ### Built-in recipes
 
-TiNy includes comprehensive built-in recipes for modern mobile development. All recipes support the current Titanium SDK platforms and device types.
+The built-in recipes cover the most common build configurations. A few things worth knowing:
 
-**Recipe Usage:**
+- Recipes expand to full Titanium CLI arguments
+- The first recipe in a command doesn't need the `--` prefix
+- Multiple recipes can be combined in a single command
 
-- Recipes are command-line flags that expand to full Titanium CLI arguments
-- When used as the first argument, recipes don't need the `--` prefix
-- Recipes can be combined and chained for complex build configurations
+**Apple / iOS**
 
-| name              | recipe                                                 |
-| ----------------- | ------------------------------------------------------ |
-| android           | --platform android                                     |
-| ios               | --platform ios                                         |
-| ipad              | --device-family ipad                                   |
-| iphone            | --device-family iphone                                 |
-| ip                | --iphone                                               |
-| universal         | --device-family universal                              |
-| uni               | --universal                                            |
-| watch             | --ios --launch-watch-app                               |
-| mac               | --platform ios --target macos                          |
-| catalyst          | --mac                                                  |
-| appstore          | --ios --target dist-appstore                           |
-| as                | --appstore                                             |
-| macstore          | --ios --target dist-macappstore                        |
-| playstore         | --android --target dist-playstore                      |
-| play              | --playstore                                            |
-| ps                | --playstore                                            |
-| adhoc             | --ios --target dist-adhoc                              |
-| ah                | --adhoc                                                |
-| emulator          | --target emulator                                      |
-| emu               | --emulator                                             |
-| simulator         | --target simulator                                     |
-| sim               | --simulator                                            |
-| device            | --target device                                        |
-| ioses             | --ios --device --device-id all                         |
-| droid             | --android --device                                     |
-| desktop           | -output-dir ~/Desktop                                  |
-| ip18              | --sim-version 18.6 --sim-type iphone                   |
-| ip26              | --sim-version 26.1 --sim-type iphone                   |
-| ipad18            | --sim-version 18.6 --sim-type ipad                     |
-| ipad26            | --sim-version 26.1 --sim-type ipad                     |
-| key-password      | --key-password %s --key-password %s --platform android |
-| android-sdk       | --android-sdk %s --platform android                    |
-| avd-abi           | --avd-abi %s --platform android                        |
-| keystore          | --keystore %s --platform android                       |
-| alias             | --alias %s --platform android                          |
-| store-password    | --store-password %s --platform android                 |
-| device-family     | --device-family %s --platform ios                      |
-| ios-version       | --ios-version %s --platform ios                        |
-| pp-uuid           | --pp-uuid %s --platform ios                            |
-| distribution-name | --distribution-name %s --platform ios                  |
-| sim-version       | --sim-version %s --target simulator --platform ios     |
-| keychain          | --keychain %s --platform ios                           |
-| developer-name    | --developer-name %s --target device --platform ios     |
-| sim-type          | --sim-type %s --target simulator --platform ios        |
+| name      | recipe                        |
+| --------- | ----------------------------- |
+| ios       | --platform ios                |
+| ip        | --iphone                      |
+| ipad      | --device-family ipad          |
+| iphone    | --device-family iphone        |
+| mac       | --platform ios --target macos |
+| catalyst  | --mac                         |
+| sim       | --simulator                   |
+| simulator | --target simulator            |
+| uni       | --universal                   |
+| universal | --device-family universal     |
+| watch     | --ios --launch-watch-app      |
+
+**Android**
+
+| name     | recipe             |
+| -------- | ------------------ |
+| android  | --platform android |
+| droid    | --android --device |
+| emu      | --emulator         |
+| emulator | --target emulator  |
+
+**Distribution**
+
+| name      | recipe                            |
+| --------- | --------------------------------- |
+| appstore  | --ios --target dist-appstore      |
+| as        | --appstore                        |
+| macstore  | --ios --target dist-macappstore   |
+| adhoc     | --ios --target dist-adhoc         |
+| ah        | --adhoc                           |
+| playstore | --android --target dist-playstore |
+| play      | --playstore                       |
+| ps        | --playstore                       |
+
+**iPhone Simulators**
+
+| name | recipe                               |
+| ---- | ------------------------------------ |
+| ip18 | --sim-version 18.6 --sim-type iphone |
+| ip26 | --sim-version 26.1 --sim-type iphone |
+
+**iPad Simulators**
+
+| name   | recipe                             |
+| ------ | ---------------------------------- |
+| ipad18 | --sim-version 18.6 --sim-type ipad |
+| ipad26 | --sim-version 26.1 --sim-type ipad |
+
+**iOS Devices**
+
+| name  | recipe                         |
+| ----- | ------------------------------ |
+| ioses | --ios --device --device-id all |
+
+**Aliases**
+
+Short forms for commonly used recipes. Each alias expands to a single flag that maps to an existing recipe.
+
+| alias    | expands to |
+| -------- | ---------- |
+| ah       | adhoc      |
+| as       | appstore   |
+| catalyst | mac        |
+| emu      | emulator   |
+| ip       | iphone     |
+| play     | playstore  |
+| ps       | playstore  |
+| sim      | simulator  |
+| uni      | universal  |
+
+**Misc**
+
+| name    | recipe                |
+| ------- | --------------------- |
+| desktop | -output-dir ~/Desktop |
+| device  | --target device       |
+
+**Parametric recipes (iOS)**
+
+These recipes accept a value that replaces `%s` in the expanded command. Useful when composing custom recipes with `tn save`.
+
+| name              | recipe                                             | description                                                         |
+| ----------------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| device-family     | --device-family %s --platform ios                  | Target device family: `iphone`, `ipad`, or `universal`              |
+| developer-name    | --developer-name %s --target device --platform ios | Developer certificate name for device builds (e.g. `"John (T3AM)"`) |
+| distribution-name | --distribution-name %s --platform ios              | Distribution certificate name for App Store or Ad Hoc signing       |
+| ios-version       | --ios-version %s --platform ios                    | Target iOS SDK version (e.g. `18.0`)                                |
+| keychain          | --keychain %s --platform ios                       | Path to the macOS keychain file containing signing certificates     |
+| pp-uuid           | --pp-uuid %s --platform ios                        | Provisioning Profile UUID for app signing                           |
+| sim-type          | --sim-type %s --target simulator --platform ios    | Simulator type: `iphone` or `ipad`                                  |
+| sim-version       | --sim-version %s --target simulator --platform ios | iOS version of the simulator to target (e.g. `18.6`)                |
+
+**Parametric recipes (Android)**
+
+| name           | recipe                                                 | description                                                          |
+| -------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| alias          | --alias %s --platform android                          | Keystore entry alias (the name given when the key was created)       |
+| android-sdk    | --android-sdk %s --platform android                    | Override the path to the Android SDK installation                    |
+| avd-abi        | --avd-abi %s --platform android                        | ABI architecture of the emulator (e.g. `x86_64`, `arm64-v8a`)        |
+| key-password   | --key-password %s --key-password %s --platform android | Password for the signing key inside the keystore                     |
+| keystore       | --keystore %s --platform android                       | Path to the `.keystore` file used to sign the APK/AAB                |
+| store-password | --store-password %s --platform android                 | Password for the keystore file itself (distinct from `key-password`) |
 
 ### Custom recipes
 
@@ -228,7 +286,7 @@ tn release
 
 ### Resolving aliases
 
-TiNy will convert abbreviations (`-T`) to their full names (`--target`). It needs to this for the next feature.
+TiNy converts abbreviations (`-T`) to their full names (`--target`) to support duplicate resolution.
 
 ### Resolving duplicates
 
@@ -236,32 +294,27 @@ TiNy will resolve any duplicate options and flags in order of appearance.
 
 ## Features
 
-### Modern Architecture (v5.0.0)
+### Changes in v5.0.0
 
-- **Node.js 18+ Support**: Fully compatible with modern Node.js versions
-- **Enhanced Security**: Updated all dependencies to latest secure versions
-- **Modern Dependencies**: Uses lodash, chalk, @inquirer/prompts for better performance
-- **Code Quality**: ESLint 8, Prettier formatting, comprehensive testing setup
+- Requires Node.js 18+ (Titanium CLI needs 20.18.1+)
+- Switched to lodash, chalk, and @inquirer/prompts
+- Dropped support for platforms other than iOS and Android
+- Added ESLint 8 and Prettier
 
-### Device Management
+### Device management
 
-- **Automatic Discovery**: `tn generate` detects all connected iOS simulators and Android emulators
-- **Current Devices**: Supports iPhone 16 series, iPad Air M3, iPad Pro M4, latest Android emulators
-- **Real Device Support**: Works with physical iOS and Android devices
+`tn generate` detects all connected iOS simulators, Android emulators, and physical devices and writes a recipe for each. Supports current hardware including iPhone 16 series, iPad Air M3, iPad Pro M4, and recent Android emulators.
 
-### Recipe System
+### Recipe system
 
-- **Built-in Recipes**: 50+ pre-configured recipes for common build scenarios
-- **Custom Recipes**: Save, edit, and share your own recipe configurations
-- **Project Recipes**: Per-project recipe files for team collaboration
-- **Recipe Chaining**: Combine multiple recipes in a single command
+Ships with 40+ built-in recipes. Save your own with `tn save`, keep per-project recipes in `tn.json`, and chain multiple recipes in a single command.
 
-### Developer Experience
+### Other
 
-- **Interactive Prompts**: Modern CLI prompts for recipe management and execution
-- **Verbose Mode**: Detailed output showing recipe expansion and build process
-- **Safety Features**: Protection against accidental configuration deletion
-- **Modern CLI**: Uses Titanium SDK CLI (`ti`) exclusively
+- `--verbose` shows each expansion step and the final command before running
+- Interactive prompts let you save or cancel before executing
+- Safety checks prevent accidental deletion of recipe files
+- Uses Titanium SDK CLI (`ti`) exclusively
 
 ## Changelog
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,6 +6,7 @@ const { spawn } = require('child_process');
 const chalk = require('chalk');
 
 const pkg = require('../package.json'),
+  clean = require('../lib/clean'),
   recipes = require('../lib/recipes'),
   setup = require('../lib/setup'),
   utils = require('../lib/utils'),
@@ -88,6 +89,13 @@ else if (cmd === '-v' || cmd === '--version' || cmd === 'version') {
     setup.generate();
   }
 
+  // clean
+  else if (cmd === 'clean') {
+    displayBanner();
+
+    clean.run(args).catch(handlePromptExit);
+  }
+
   // no args
   else if (!cmd) {
     displayHelp();
@@ -137,6 +145,20 @@ else if (cmd === '-v' || cmd === '--version' || cmd === 'version') {
   }
 }
 
+// Ctrl+C at a prompt is a normal way to say no, not a crash. Without this the
+// user gets an ExitPromptError stack trace.
+function handlePromptExit(err) {
+  if (err && err.name === 'ExitPromptError') {
+    console.log();
+    return;
+  }
+
+  throw err;
+}
+
+// generate() prompts from inside a spawn callback, so its rejection surfaces here
+process.on('unhandledRejection', handlePromptExit);
+
 // help
 function displayHelp() {
   displayBanner();
@@ -184,6 +206,16 @@ function displayHelp() {
       'generates simulators/device user-recipes (' +
       chalk.yellow('tn iphone6plus') +
       ')'
+  );
+  console.log();
+  console.log(
+    '  ' + chalk.cyan('clean') + '\t\t\t\t' + 'deletes iOS simulators whose runtime is gone'
+  );
+  console.log(
+    '  ' + chalk.cyan('clean --data') + '\t\t\t' + 'erases contents and settings, keeps simulators'
+  );
+  console.log(
+    '  ' + chalk.cyan('clean --runtimes') + '\t\t' + 'deletes installed iOS runtimes you pick'
   );
   console.log();
   console.log(

--- a/docs/superpowers/specs/2026-07-30-tn-clean-design.md
+++ b/docs/superpowers/specs/2026-07-30-tn-clean-design.md
@@ -1,0 +1,228 @@
+# `tn clean` — limpieza de simuladores iOS
+
+Fecha: 2026-07-30
+Estado: aprobado, pendiente de implementación
+
+## Problema
+
+Xcode no limpia detrás de sí. Cuando se desinstala un runtime, sus simuladores
+quedan en `~/Library/Developer/CoreSimulator/Devices` como "fantasmas": siguen
+en `simctl list` pero con `isAvailable: false` y `availabilityError: "runtime
+profile not found"`. Nunca se borran solos.
+
+Medido en la máquina de referencia (2026-07-30) tras desinstalarse el runtime
+iOS 26.4:
+
+| Concepto | Espacio |
+| --- | --- |
+| 11 simuladores fantasma de iOS 26.4 | 14 GB |
+| `~/Library/Developer/CoreSimulator/Devices` (total) | 43 GB |
+| Imágenes de runtime (iOS 18.6 + 26.5) | 16.1 GB |
+
+Además, esos fantasmas ensuciaban `tn generate`: `ti info` los reporta como si
+existieran, así que TiNy generaba recetas para ellos que la poda de huérfanas
+borraba acto seguido, en un bucle infinito. Ese defecto se corrige por separado
+(filtrado por `simctl` en la generación); `tn clean` ataca la causa de raíz,
+que es la basura en disco.
+
+## Alcance
+
+Dentro:
+
+- Borrar simuladores iOS fantasma.
+- Borrar contenidos y ajustes de simuladores vivos (`--data`).
+- Borrar imágenes de runtime iOS (`--runtimes`).
+- Podar las recetas de TiNy que queden huérfanas por cualquiera de esas
+  operaciones.
+
+Fuera:
+
+- Emuladores de Android. `avdmanager` es otro modelo y no ofrece un equivalente
+  a `delete unavailable`. Queda para una versión posterior si hace falta.
+- watchOS, tvOS y visionOS como caso a tratar aparte. `simctl delete unavailable`
+  no distingue plataforma, así que si hay fantasmas de esas se listan y se
+  borran junto con los de iOS: la lista muestra exactamente lo que se va a
+  borrar, agrupada por runtime.
+
+## Superficie del comando
+
+```
+tn clean                    # solo fantasmas
+tn clean --ghosts           # idéntico, explícito, para combinar
+tn clean --data             # erase de simuladores disponibles
+tn clean --runtimes         # borrar imágenes de runtime, eligiendo cuáles
+tn clean --data --runtimes  # se combinan
+```
+
+Reglas de la superficie:
+
+1. Sin banderas equivale a `--ghosts`. Es el caso seguro y el habitual.
+2. Con banderas se hace **solo** lo pedido. `tn clean --data` no barre fantasmas
+   de pasada. Nada implícito.
+3. No existe `--all`. Borrar 30 GB no debe caber en un tab-complete distraído.
+4. Toda operación se confirma mostrando qué se borra y cuánto espacio libera,
+   con el prompt en `No` por defecto, igual que la poda de recetas huérfanas.
+
+## Primitivas de `simctl`
+
+Verificadas en Xcode con runtimes iOS 18.6 y 26.5 instalados:
+
+| Operación | Comando | Notas |
+| --- | --- | --- |
+| Listar dispositivos | `xcrun simctl list devices --json` | trae `isAvailable`, `state`, `dataPath` |
+| Borrar fantasmas | `xcrun simctl delete unavailable` | "delete devices that are not supported by the current Xcode SDK" |
+| Borrar datos | `xcrun simctl erase <udid> [...]` | conserva el simulador |
+| Listar runtimes | `xcrun simctl runtime list --json` | trae `sizeBytes`, `lastUsedAt`, `deletable`, `version` |
+| Borrar runtime | `xcrun simctl runtime delete <identifier>` | acepta varios identificadores |
+
+El tamaño de los simuladores no lo da `simctl`; se calcula con `du -sk` sobre el
+directorio padre de `dataPath`. Medido: ~4.5 s para 11 simuladores. Se muestra
+un aviso mientras se calcula.
+
+## Arquitectura
+
+Módulo nuevo `lib/clean.js`, en la línea de `lib/setup.js`: expone una función
+por operación más el orquestador que `bin/cli.js` invoca.
+
+```
+bin/cli.js
+  └── cmd === 'clean' → clean.run(flags)
+
+lib/clean.js
+  ├── run(flags)                    orquesta según banderas, en orden seguro
+  ├── listGhosts()                  → [{ udid, name, runtime, path }]
+  ├── listLiveSimulators()          → [{ udid, name, state }]
+  ├── listRuntimes()                → [{ id, name, version, sizeBytes, lastUsedAt }]
+  ├── cleanGhosts()                 confirma y ejecuta `delete unavailable`
+  ├── cleanData()                   confirma y ejecuta `erase`
+  ├── cleanRuntimes()               elige cuáles, confirma y ejecuta `runtime delete`
+  └── dirSize(paths)                `du -sk`, para reportar espacio
+
+lib/simctl.js
+  └── envoltorio único de `xcrun simctl ... --json` con manejo de fallo
+
+lib/setup.js
+  └── pruneOrphanRecipes(iosSet, androidSet)   extraído del bloque actual de
+      generate() para que clean.js lo reutilice
+```
+
+`lib/setup.js` ya consulta `simctl` para saber qué simuladores están activos.
+Esa llamada se traslada a `lib/simctl.js` y ambos módulos la consumen, en vez de
+duplicarla. Es el único refactor de código existente que contempla este diseño.
+
+## Flujo por bandera
+
+### `--ghosts` (por defecto)
+
+1. Leer `simctl list devices --json`, quedarse con `isAvailable === false`.
+2. Si no hay ninguno: `No ghost simulators found.` y terminar.
+3. Calcular tamaño en disco y listar los fantasmas agrupados por runtime.
+4. Confirmar. Si acepta, ejecutar `simctl delete unavailable`.
+5. Podar recetas huérfanas (ver más abajo).
+
+### `--data`
+
+1. Listar simuladores con `isAvailable === true`.
+2. **Omitir los que estén en estado `Booted`**, avisando cuáles y por qué. Es
+   determinista y evita depender de si `erase` acepta o no ese estado.
+3. Calcular tamaño y confirmar.
+4. Ejecutar `simctl erase <udid> ...` con la lista explícita de UDIDs. No se usa
+   `erase all`, para no tocar lo omitido en el paso 2.
+5. No hay poda de recetas: los simuladores siguen existiendo.
+
+### `--runtimes`
+
+1. Leer `simctl runtime list --json`, descartar los que traigan
+   `deletable: false`.
+2. Presentar cada runtime con versión, tamaño y fecha de último uso, y dejar
+   elegir cuáles borrar con un `checkbox` de `@inquirer/prompts`. Ninguno viene
+   preseleccionado.
+3. Si se elige el runtime más nuevo instalado, advertirlo de forma explícita
+   antes de la confirmación final.
+4. Confirmar y ejecutar `simctl runtime delete <id> ...`.
+5. Borrar un runtime convierte sus simuladores en fantasmas. Encadenar de
+   inmediato el barrido de fantasmas, sin volver a preguntar: ya se confirmó el
+   borrado del runtime del que dependen. `simctl delete unavailable` no
+   discrimina, así que si había fantasmas previos también caen; el resumen los
+   cuenta por separado en vez de atribuirlos todos al runtime recién borrado.
+6. Podar recetas huérfanas.
+
+### Orden cuando se combinan banderas
+
+`--data` → `--runtimes` → `--ghosts`. Los runtimes van antes que los fantasmas
+porque generan fantasmas nuevos, y así una sola pasada final los recoge todos.
+
+## Poda de recetas
+
+Tras borrar simuladores, las recetas de usuario que apuntaban a ellos quedan
+colgando. `clean` reutiliza `pruneOrphanRecipes()`, el mismo código que usa
+`tn generate`: releer `simctl` ya sin lo borrado, comparar contra `~/.tn.json`,
+listar las huérfanas y ofrecer quitarlas con el prompt en `No`.
+
+Es una confirmación aparte de la del borrado en disco. Son dos decisiones
+distintas y el usuario puede querer conservar los nombres de sus recetas.
+
+## Integración con `tn generate`
+
+`generate` **no** borra nada ni pregunta nada nuevo. Si detecta fantasmas,
+imprime una sola línea informativa:
+
+```
+[WARN]  11 ghost simulators found — their runtime is no longer installed
+        Run  tn clean  to remove them and free up disk space.
+```
+
+Va como `warn`, no como `info`: en una columna de mensajes idénticos la línea
+se perdía. La etiqueta amarilla y el renglón aparte para el comando la separan
+del resto.
+
+Sin esta línea el usuario nunca se enteraría, porque tras el arreglo del bucle
+`generate` ignora los fantasmas por completo.
+
+`generate` informa el conteo pero **no** el tamaño: el `du` cuesta ~4.5 s y no
+se justifica en cada corrida. El tamaño se calcula en `tn clean`, donde sí es
+la decisión que se está tomando.
+
+## Manejo de errores
+
+- **`xcrun` no existe o falla** (no hay Xcode, no es macOS): mensaje claro
+  (`tn clean requires Xcode command line tools on macOS`) y salida sin error de
+  ejecución. Mismo criterio que ya usa `getActiveIosUdidsFromSimctl`, que
+  devuelve `null` ante cualquier fallo.
+- **JSON ilegible**: se trata como fallo de la consulta; no se borra nada.
+- **Un borrado falla** (permisos, simulador en uso): se reporta el fallo con lo
+  que devolvió `simctl` y se continúa con los demás. Al final se resume qué se
+  borró y qué no.
+- **El usuario cancela el prompt** (Ctrl+C): salir limpio, sin traza de
+  `ExitPromptError`.
+
+## Verificación
+
+El proyecto no tiene framework de pruebas, así que la verificación es manual y
+con criterios comprobables antes de dar nada por terminado:
+
+| Escenario | Comprobación |
+| --- | --- |
+| Hay fantasmas | `tn clean` los lista con su tamaño; al aceptar, `simctl list devices --json` ya no reporta ninguno con `isAvailable:false` |
+| No hay fantasmas | `tn clean` dice `No ghost simulators found.` y no invoca `delete` |
+| Se responde que No | `~/.tn.json` y `simctl list` quedan idénticos (comparación byte a byte contra copia previa) |
+| `--runtimes` | `simctl runtime list` pierde el elegido; los fantasmas que genera se barren en la misma corrida |
+| `--data` con un simulador booteado | ese simulador se omite y se avisa; los demás quedan con `erase` aplicado |
+| Sin Xcode | mensaje claro, sin traza de excepción |
+| Recetas huérfanas | tras borrar, se ofrecen las afectadas y solo esas |
+
+Cada corrida de verificación se hace con copia previa de `~/.tn.json` para poder
+comparar y restaurar.
+
+## Decisiones tomadas
+
+- **Tres banderas, no un solo comando que lo haga todo.** Son tres problemas con
+  tres perfiles de riesgo distintos: los fantasmas no sirven para nada, los
+  datos se reinstalan, y un runtime borrado son varios GB de descarga.
+- **Sin `--all`.** Combinar banderas a propósito es un acto deliberado; `--all`
+  no lo es.
+- **`--runtimes` encadena la limpieza de fantasmas.** Es lo que aporta TiNy
+  sobre `simctl` pelón: TiNy sabe de recetas, `simctl` no.
+- **Android fuera.** Sin equivalente limpio a `delete unavailable`.
+- **Sin `--dry-run` propio.** El prompt en `No` mostrando la lista completa ya
+  cumple esa función; añadir una bandera para lo mismo sobra.

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,0 +1,391 @@
+// `tn clean` — removes iOS simulator junk that Xcode leaves behind.
+//
+// Three separate jobs with three separate risk profiles, so three separate
+// flags. Ghost simulators are useless by definition and are the default. Erased
+// data comes back by reinstalling. A deleted runtime is a multi-gigabyte
+// download, so it is never touched unless asked for by name.
+
+const path = require('path');
+const { spawn } = require('child_process');
+
+const { confirm, checkbox } = require('@inquirer/prompts');
+
+const chalk = require('chalk');
+
+const logger = require('./logger'),
+  setup = require('./setup'),
+  simctl = require('./simctl');
+
+exports.run = run;
+
+const FLAGS = ['--ghosts', '--data', '--runtimes'];
+
+async function run(argv) {
+  const flags = argv || [];
+  const unknown = flags.filter(flag => FLAGS.indexOf(flag) === -1);
+
+  if (unknown.length > 0) {
+    logger.error('Unknown option: ' + chalk.yellow(unknown.join(' ')));
+    logger.info('Usage: tn clean [--ghosts] [--data] [--runtimes]');
+    return;
+  }
+
+  const doData = flags.indexOf('--data') !== -1;
+  const doRuntimes = flags.indexOf('--runtimes') !== -1;
+  // no flags at all means the safe, common case
+  const doGhosts = flags.indexOf('--ghosts') !== -1 || (!doData && !doRuntimes);
+
+  if ((await simctl.getDevices()) === null) {
+    logger.error('tn clean requires the Xcode command line tools on macOS');
+    return;
+  }
+
+  // Data first, then runtimes, then ghosts: deleting a runtime creates new
+  // ghosts, so sweeping them last catches everything in one pass.
+  let deletedSimulators = false;
+
+  if (doData) {
+    await cleanData();
+  }
+
+  if (doRuntimes) {
+    deletedSimulators = (await cleanRuntimes()) || deletedSimulators;
+  }
+
+  if (doGhosts) {
+    deletedSimulators = (await cleanGhosts()) || deletedSimulators;
+  }
+
+  if (deletedSimulators) {
+    const devices = await simctl.getDevices();
+
+    // Android is not inspected here, so its set is unknown and its recipes are
+    // left alone.
+    await setup.pruneOrphanRecipes(devices ? simctl.activeUdids(devices) : null, null);
+  }
+
+  logger.info('Done');
+}
+
+async function cleanGhosts() {
+  const devices = await simctl.getDevices();
+  const ghosts = simctl.ghosts(devices);
+
+  if (ghosts.length === 0) {
+    logger.info('No ghost simulators found.');
+    return false;
+  }
+
+  logger.info(
+    'Found ' + ghosts.length + ' ghost simulators (their runtime is no longer installed):'
+  );
+  printByRuntime(ghosts);
+
+  const bytes = await measure(ghosts);
+
+  if (bytes !== null) {
+    logger.info('They are using ' + chalk.yellow(formatSize(bytes)) + ' on disk.');
+  }
+
+  console.log();
+
+  const ok = await confirm({ message: 'Delete these simulators?', default: false });
+
+  if (!ok) {
+    logger.info('Keeping ghost simulators.');
+    return false;
+  }
+
+  return deleteGhosts(ghosts.length, bytes);
+}
+
+async function deleteGhosts(count, bytes) {
+  const res = await simctl.exec(['delete', 'unavailable']);
+
+  if (res.code !== 0) {
+    logger.error('Failed to delete ghost simulators: ' + res.stderr.trim());
+    return false;
+  }
+
+  logger.info(
+    'Deleted ' +
+      count +
+      ' ghost simulators' +
+      (bytes ? ', freeing ' + chalk.green(formatSize(bytes)) : '') +
+      '.'
+  );
+
+  return true;
+}
+
+async function cleanData() {
+  const devices = await simctl.getDevices();
+  const live = (devices || []).filter(dev => dev.isAvailable);
+  // A booted simulator is skipped rather than shut down: erasing what you are
+  // actively using is not something a cleanup command should decide for you.
+  const booted = live.filter(dev => dev.state === 'Booted');
+  const targets = live.filter(dev => dev.state !== 'Booted');
+
+  if (booted.length > 0) {
+    logger.warn(
+      'Skipping ' +
+        booted.length +
+        ' booted simulator(s): ' +
+        booted.map(dev => dev.name).join(', ')
+    );
+  }
+
+  if (targets.length === 0) {
+    logger.info('No simulators to erase.');
+    return false;
+  }
+
+  logger.info('This erases contents and settings of ' + targets.length + ' simulators.');
+  logger.info(chalk.yellow('Installed apps and their data are deleted. The simulators are kept.'));
+
+  const bytes = await measure(targets);
+
+  if (bytes !== null) {
+    logger.info('They are using ' + chalk.yellow(formatSize(bytes)) + ' on disk.');
+  }
+
+  console.log();
+
+  const ok = await confirm({
+    message: 'Erase contents and settings of ' + targets.length + ' simulators?',
+    default: false,
+  });
+
+  if (!ok) {
+    logger.info('Keeping simulator data.');
+    return false;
+  }
+
+  // explicit UDIDs rather than `erase all`, so the booted ones stay skipped
+  const res = await simctl.exec(['erase'].concat(targets.map(dev => dev.udid)));
+
+  if (res.code !== 0) {
+    logger.error('Failed to erase simulators: ' + res.stderr.trim());
+    return false;
+  }
+
+  logger.info('Erased ' + targets.length + ' simulators.');
+  return false;
+}
+
+async function cleanRuntimes() {
+  const runtimes = await simctl.getRuntimes();
+
+  if (runtimes === null) {
+    logger.error('Failed to read installed runtimes.');
+    return false;
+  }
+
+  const deletable = runtimes.filter(rt => rt.deletable);
+
+  if (deletable.length === 0) {
+    logger.info('No deletable runtimes found.');
+    return false;
+  }
+
+  // counted before anything is deleted, so the summary can tell the simulators
+  // this command orphaned apart from the ones that were already ghosts
+  const ghostsBefore = simctl.ghosts(await simctl.getDevices()).length;
+
+  deletable.sort((a, b) => compareVersions(b.version, a.version));
+
+  console.log();
+
+  const picked = await checkbox({
+    message: 'Select runtimes to delete (nothing is selected by default):',
+    choices: deletable.map(rt => ({
+      name:
+        rt.name +
+        ' (' +
+        rt.build +
+        ') — ' +
+        formatSize(rt.sizeBytes) +
+        (rt.lastUsedAt ? ', last used ' + rt.lastUsedAt.slice(0, 10) : ''),
+      value: rt.id,
+    })),
+  });
+
+  if (picked.length === 0) {
+    logger.info('No runtimes selected.');
+    return false;
+  }
+
+  const chosen = deletable.filter(rt => picked.indexOf(rt.id) !== -1);
+  const newest = newestPerPlatform(deletable);
+
+  chosen.forEach(rt => {
+    if (newest[rt.platform] === rt.id) {
+      // rt.name is "iOS 26.5", so its first word is the platform label
+      logger.warn(
+        chalk.yellow(
+          rt.name + ' is the newest ' + rt.name.split(' ')[0] + ' runtime you have installed.'
+        )
+      );
+    }
+  });
+
+  const bytes = chosen.reduce((sum, rt) => sum + (rt.sizeBytes || 0), 0);
+
+  console.log();
+  logger.info('Re-downloading a runtime later takes several gigabytes and a while.');
+  console.log();
+
+  const ok = await confirm({
+    message: 'Delete ' + chosen.length + ' runtime(s), freeing ' + formatSize(bytes) + '?',
+    default: false,
+  });
+
+  if (!ok) {
+    logger.info('Keeping runtimes.');
+    return false;
+  }
+
+  const res = await simctl.exec(['runtime', 'delete'].concat(picked));
+
+  if (res.code !== 0) {
+    logger.error('Failed to delete runtimes: ' + res.stderr.trim());
+    return false;
+  }
+
+  logger.info(
+    'Deleted ' + chosen.length + ' runtime(s), freeing ' + chalk.green(formatSize(bytes)) + '.'
+  );
+
+  // Deleting a runtime turns its simulators into ghosts. Sweep them without
+  // asking again: removing the runtime they depend on was already confirmed.
+  const devices = await simctl.getDevices();
+  const ghosts = simctl.ghosts(devices);
+
+  if (ghosts.length === 0) {
+    return true;
+  }
+
+  const orphaned = ghosts.length - ghostsBefore;
+
+  logger.info(
+    ghostsBefore > 0
+      ? 'Removing ' +
+          ghosts.length +
+          ' unusable simulators (' +
+          orphaned +
+          ' left behind by the deleted runtime(s), ' +
+          ghostsBefore +
+          ' already ghosts)..'
+      : 'Removing ' + orphaned + ' simulators left behind by the deleted runtime(s)..'
+  );
+
+  await deleteGhosts(ghosts.length, await measure(ghosts));
+
+  return true;
+}
+
+function newestPerPlatform(runtimes) {
+  const newest = {};
+
+  runtimes.forEach(rt => {
+    const current = newest[rt.platform];
+
+    if (!current || compareVersions(rt.version, current.version) > 0) {
+      newest[rt.platform] = rt;
+    }
+  });
+
+  Object.keys(newest).forEach(platform => {
+    newest[platform] = newest[platform].id;
+  });
+
+  return newest;
+}
+
+function compareVersions(a, b) {
+  const left = String(a).split('.').map(Number);
+  const right = String(b).split('.').map(Number);
+
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (left[i] || 0) - (right[i] || 0);
+
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  return 0;
+}
+
+function printByRuntime(devices) {
+  const groups = {};
+
+  devices.forEach(dev => {
+    (groups[dev.runtime] = groups[dev.runtime] || []).push(dev);
+  });
+
+  Object.keys(groups)
+    .sort()
+    .forEach(runtime => {
+      console.log('  ' + chalk.bold(runtime));
+      groups[runtime].forEach(dev => {
+        console.log('    ' + chalk.red(dev.name));
+      });
+    });
+
+  console.log();
+}
+
+// simctl does not report per-device size, so shell out to du. Costs a few
+// seconds over a large Devices folder, which is why generate() never does this.
+async function measure(devices) {
+  const paths = devices.filter(dev => dev.dataPath).map(dev => path.dirname(dev.dataPath));
+
+  if (paths.length === 0) {
+    return null;
+  }
+
+  logger.info('Calculating disk usage..');
+
+  return dirSize(paths);
+}
+
+function dirSize(paths) {
+  return new Promise(resolve => {
+    const proc = spawn('du', ['-sk'].concat(paths), { stdio: ['ignore', 'pipe', 'ignore'] });
+    let out = '';
+
+    proc.stdout.on('data', data => {
+      out += data;
+    });
+
+    proc.on('error', () => resolve(null));
+    proc.on('close', () => {
+      let total = 0;
+
+      out.split('\n').forEach(line => {
+        const kb = parseInt(line, 10);
+
+        if (!isNaN(kb)) {
+          total += kb;
+        }
+      });
+
+      resolve(total * 1024);
+    });
+  });
+}
+
+function formatSize(bytes) {
+  if (!bytes) {
+    return '0 B';
+  }
+
+  const gb = bytes / 1024 / 1024 / 1024;
+
+  if (gb >= 1) {
+    return gb.toFixed(1) + ' GB';
+  }
+
+  return Math.round(bytes / 1024 / 1024) + ' MB';
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,8 +2,11 @@ const chalk = require('chalk'),
   _ = require('lodash');
 
 const levels = {
+  // Printed without a label: when every line carries one it stops meaning
+  // anything, and warnings and errors are the ones worth spotting.
   info: {
     color: chalk.white,
+    bare: true,
   },
   trace: {
     color: chalk.gray,
@@ -26,7 +29,14 @@ const levels = {
 
 _.each(levels, function (settings, label) {
   exports[label] = function (msg) {
-    console[settings.level || label](
+    const out = console[settings.level || label];
+
+    if (settings.bare) {
+      out(msg);
+      return;
+    }
+
+    out(
       settings.color('[' + label.toUpperCase() + ']') +
         (label.length !== 5 ? new Array(6 - label.length).join(' ') : '') +
         ' ' +

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -19,9 +19,30 @@ const path_user = path.join(path_home, '.tn.json');
 const path_project = path.join(process.cwd(), 'tn.json');
 
 const recipes_system = require('./../tn.json');
-const recipes_user = fs.existsSync(path_user) ? require(path_user) : {};
-const recipes_project = fs.existsSync(path_project) ? require(path_project) : {};
+const recipes_user = read(path_user);
+const recipes_project = read(path_project);
 let recipes_combined = _.extend({}, recipes_system, recipes_user, recipes_project);
+
+// These files are meant to be hand-edited, so a stray comma is a matter of time.
+// A broken one is reported and skipped: taking down every single command over a
+// typo would leave no way to even list the recipes and find it.
+function read(file) {
+  if (!fs.existsSync(file)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    logger.error('Ignoring ' + chalk.yellow(file) + ': ' + e.message);
+    return {};
+  }
+}
+
+// Written indented because the user is expected to open and edit this.
+function write(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+}
 
 function has(name) {
   return _.has(recipes_combined, name);
@@ -167,9 +188,9 @@ function list(forReadMe) {
     const isGeneral = group === 'General';
     const items = isGeneral
       ? members.slice().sort(function (a, b) {
-          const diff = generalSubgroup(recipes_combined[a]) - generalSubgroup(recipes_combined[b]);
-          return diff !== 0 ? diff : systemFirst(a, b);
-        })
+        const diff = generalSubgroup(recipes_combined[a]) - generalSubgroup(recipes_combined[b]);
+        return diff !== 0 ? diff : systemFirst(a, b);
+      })
       : members;
 
     let lastSubgroup = null;
@@ -192,7 +213,7 @@ function list(forReadMe) {
         lastSubgroup = sg;
       }
 
-      let commands = _.isString(args) ? ' ' + args : utils.join(args);
+      const commands = _.isString(args) ? ' ' + args : utils.join(args);
       console.log('  ' + recipe + ': ' + chalk[color](commands));
     });
 
@@ -225,10 +246,10 @@ function save(recipe, args, location, silent) {
 
   if (location == 'project') {
     recipes_combined[recipe] = recipes_project[recipe] = args;
-    fs.writeFileSync(path_project, JSON.stringify(recipes_project));
+    write(path_project, recipes_project);
   } else {
     recipes_combined[recipe] = recipes_user[recipe] = args;
-    fs.writeFileSync(path_user, JSON.stringify(recipes_user));
+    write(path_user, recipes_user);
   }
 
   let clr;
@@ -264,10 +285,10 @@ function remove(recipe, location, silent) {
 
   if (location == 'project') {
     delete recipes_project[recipe];
-    fs.writeFileSync(path_project, JSON.stringify(recipes_project));
+    write(path_project, recipes_project);
   } else {
     delete recipes_user[recipe];
-    fs.writeFileSync(path_user, JSON.stringify(recipes_user));
+    write(path_user, recipes_user);
   }
 
   recipes_combined = _.extend({}, recipes_system, recipes_user, recipes_project);
@@ -291,15 +312,15 @@ function rename(oldRecipe, newRecipe, location) {
   if (location == 'project') {
     recipes_project[newRecipe] = recipes_project[oldRecipe];
     delete recipes_project[oldRecipe];
-    fs.writeFileSync(path_project, JSON.stringify(recipes_project));
+    write(path_project, recipes_project);
   } else {
     recipes_user[newRecipe] = recipes_user[oldRecipe];
     delete recipes_user[oldRecipe];
-    fs.writeFileSync(path_user, JSON.stringify(recipes_user));
+    write(path_user, recipes_user);
   }
 
   logger.info('Renamed recipe: ' + chalk.yellow(oldRecipe) + ' > ' + chalk.yellow(newRecipe));
-  recipes_combined = _.extend({}, recipes_system, recipes_user);
+  recipes_combined = _.extend({}, recipes_system, recipes_user, recipes_project);
 
   console.log();
 }
@@ -334,6 +355,8 @@ function reset(location) {
   console.log();
 }
 
+// A null set means "we could not determine what is installed for that platform",
+// in which case its recipes are left alone instead of being reported as orphans.
 function listOrphans(activeIosUdids, activeAndroidIds) {
   const orphans = [];
 
@@ -349,9 +372,9 @@ function listOrphans(activeIosUdids, activeAndroidIds) {
     if (!deviceId) return;
 
     if (argsArr.includes('--ios') && argsArr.includes('--simulator')) {
-      if (!activeIosUdids.has(deviceId)) orphans.push(name);
+      if (activeIosUdids && !activeIosUdids.has(deviceId)) orphans.push(name);
     } else if (argsArr.includes('--android') && argsArr.includes('--emulator')) {
-      if (!activeAndroidIds.has(deviceId)) orphans.push(name);
+      if (activeAndroidIds && !activeAndroidIds.has(deviceId)) orphans.push(name);
     }
   });
 

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -12,6 +12,7 @@ exports.save = save;
 exports.remove = remove;
 exports.rename = rename;
 exports.reset = reset;
+exports.listOrphans = listOrphans;
 
 const path_home = process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'];
 const path_user = path.join(path_home, '.tn.json');
@@ -249,7 +250,7 @@ function save(recipe, args, location, silent) {
   return { recipe, args, clr };
 }
 
-function remove(recipe, location) {
+function remove(recipe, location, silent) {
   if (!validateRecipeName(recipe)) {
     return;
   }
@@ -271,9 +272,10 @@ function remove(recipe, location) {
 
   recipes_combined = _.extend({}, recipes_system, recipes_user, recipes_project);
 
-  logger.info('Removed ' + location + ' recipe: ' + chalk.cyan(recipe));
-
-  console.log();
+  if (!silent) {
+    logger.info('Removed ' + location + ' recipe: ' + chalk.cyan(recipe));
+    console.log();
+  }
 }
 
 function rename(oldRecipe, newRecipe, location) {
@@ -330,6 +332,30 @@ function reset(location) {
   }
 
   console.log();
+}
+
+function listOrphans(activeIosUdids, activeAndroidIds) {
+  const orphans = [];
+
+  _.each(recipes_user, function (args, name) {
+    const argsArr = _.isString(args) ? args.split(' ') : args;
+
+    if (!_.isArray(argsArr)) return;
+
+    const deviceIdIndex = argsArr.indexOf('--device-id');
+    if (deviceIdIndex === -1) return;
+
+    const deviceId = argsArr[deviceIdIndex + 1];
+    if (!deviceId) return;
+
+    if (argsArr.includes('--ios') && argsArr.includes('--simulator')) {
+      if (!activeIosUdids.has(deviceId)) orphans.push(name);
+    } else if (argsArr.includes('--android') && argsArr.includes('--emulator')) {
+      if (!activeAndroidIds.has(deviceId)) orphans.push(name);
+    }
+  });
+
+  return orphans;
 }
 
 function validateRecipeName(name) {

--- a/lib/recipes.js
+++ b/lib/recipes.js
@@ -45,6 +45,79 @@ function get(name, ingredient) {
   return recipe;
 }
 
+const GROUP_ORDER = [
+  'iPhone Simulators',
+  'iPad Simulators',
+  'Android Emulators',
+  'iOS Devices',
+  'Android Devices',
+  'Distribution',
+  'Aliases',
+  'General'
+];
+
+function generalSubgroup(args) {
+  const argsArr = _.isString(args) ? args.split(' ') : args;
+  const has = (val) => argsArr.includes(val);
+  const argsStr = argsArr.join(' ');
+
+  // Config: parametric recipes with %s
+  if (argsStr.includes('%s')) return 2;
+
+  // Apple/iOS
+  if (argsStr.includes('platform ios') || has('--ios') || has('--iphone') ||
+      has('--mac') || has('--universal') || has('--device-family') ||
+      (has('--target') && has('simulator')) || has('--simulator')) return 0;
+
+  // Android
+  if (argsStr.includes('platform android') || has('--android') ||
+      has('--emulator') || (has('--target') && has('emulator'))) return 1;
+
+  // Misc (device, desktop, etc.)
+  return 3;
+}
+
+function categorizeRecipe(name, args) {
+  const argsArr = _.isString(args) ? args.split(' ') : args;
+  const has = (val) => argsArr.includes(val);
+  const argsStr = argsArr.join(' ');
+
+  // Parametric recipes always go to General
+  if (argsStr.includes('%s')) return 'General';
+
+  // Single-flag alias pointing to another recipe
+  if (argsArr.length === 1 && argsArr[0].startsWith('--') && _.has(recipes_combined, argsArr[0].slice(2))) {
+    return 'Aliases';
+  }
+
+  // Specific simulator with UDID (generated recipes)
+  if (has('--simulator') && has('--device-id')) {
+    return name.startsWith('ipad') ? 'iPad Simulators' : 'iPhone Simulators';
+  }
+
+  // sim-type based (ip18, ip26, ipad18, ipad26)
+  if (has('--sim-type')) {
+    const simType = argsArr[argsArr.indexOf('--sim-type') + 1];
+    return simType === 'ipad' ? 'iPad Simulators' : 'iPhone Simulators';
+  }
+
+  // Specific Android emulator with device-id (generated recipes)
+  if (has('--emulator') && has('--device-id')) return 'Android Emulators';
+
+  // Distribution targets (direct or via alias)
+  if (argsStr.includes('dist-') || has('--appstore') || has('--playstore') || has('--adhoc')) {
+    return 'Distribution';
+  }
+
+  // iOS real devices (ioses)
+  if (has('--ios') && has('--device') && has('--device-id')) return 'iOS Devices';
+
+  // Android real devices
+  if (has('--android') && has('--device') && has('--device-id')) return 'Android Devices';
+
+  return 'General';
+}
+
 function list(forReadMe) {
   if (forReadMe) {
     _.each(recipes_system, function (recipe, name) {
@@ -68,53 +141,85 @@ function list(forReadMe) {
   );
   console.log();
 
-  const recipes = _.keys(recipes_combined).sort();
+  // Build grouped map
+  const grouped = {};
+  GROUP_ORDER.forEach(g => { grouped[g] = []; });
 
-  _.each(recipes, function (recipe) {
+  const systemFirst = (a, b) => {
+    const diff = (_.has(recipes_system, a) ? 0 : 1) - (_.has(recipes_system, b) ? 0 : 1);
+    return diff !== 0 ? diff : a.localeCompare(b);
+  };
+
+  _.each(_.keys(recipes_combined).sort(systemFirst), function (recipe) {
     const args = recipes_combined[recipe];
-    let color;
-
-    if (_.has(recipes_project, recipe)) {
-      color = _.has(recipes_system, recipe) || _.has(recipes_user, recipe) ? 'red' : 'yellow';
-    } else if (_.has(recipes_user, recipe)) {
-      color = _.has(recipes_system, recipe) ? 'blue' : 'cyan';
-    } else {
-      color = 'green';
-    }
-
-    let commands = '';
-
-    if (_.isString(args)) {
-      commands += ' ' + args;
-    } else {
-      commands += utils.join(args);
-    }
-
-    console.log('  ' + recipe + ': ' + chalk[color](commands));
+    const group = categorizeRecipe(recipe, args);
+    grouped[group].push(recipe);
   });
 
-  console.log();
+  // Display each group
+  GROUP_ORDER.forEach(function (group) {
+    const members = grouped[group];
+    if (members.length === 0) return;
+
+    console.log(chalk.bold(group + ':'));
+
+    const isGeneral = group === 'General';
+    const items = isGeneral
+      ? members.slice().sort(function (a, b) {
+          const diff = generalSubgroup(recipes_combined[a]) - generalSubgroup(recipes_combined[b]);
+          return diff !== 0 ? diff : systemFirst(a, b);
+        })
+      : members;
+
+    let lastSubgroup = null;
+
+    items.forEach(function (recipe) {
+      const args = recipes_combined[recipe];
+      let color;
+
+      if (_.has(recipes_project, recipe)) {
+        color = _.has(recipes_system, recipe) || _.has(recipes_user, recipe) ? 'red' : 'yellow';
+      } else if (_.has(recipes_user, recipe)) {
+        color = _.has(recipes_system, recipe) ? 'blue' : 'cyan';
+      } else {
+        color = 'green';
+      }
+
+      if (isGeneral) {
+        const sg = generalSubgroup(args);
+        if (lastSubgroup !== null && sg !== lastSubgroup) console.log();
+        lastSubgroup = sg;
+      }
+
+      let commands = _.isString(args) ? ' ' + args : utils.join(args);
+      console.log('  ' + recipe + ': ' + chalk[color](commands));
+    });
+
+    console.log();
+  });
 }
 
-function save(recipe, args, location) {
+function save(recipe, args, location, silent) {
   if (!validateRecipeName(recipe)) {
     return;
   }
 
   location = location || 'user';
 
-  if (location == 'project' && _.has(recipes_project, recipe)) {
-    logger.info('Changed existing project recipe');
-  } else if (location == 'user' && _.has(recipes_user, recipe)) {
-    logger.info('Changed existing user recipe');
-  } else if (location == 'project' && _.has(recipes_user, recipe)) {
-    logger.info('Saved project recipe, overriding user');
-  } else if (location === 'project' && _.has(recipes_system, recipe)) {
-    logger.info('Saved project recipe, overriding built-in');
-  } else if (location === 'user' && _.has(recipes_system, recipe)) {
-    logger.info('Saved user recipe, overriding built-in');
-  } else {
-    logger.info('Saved ' + location + ' recipe');
+  if (!silent) {
+    if (location == 'project' && _.has(recipes_project, recipe)) {
+      logger.info('Changed existing project recipe');
+    } else if (location == 'user' && _.has(recipes_user, recipe)) {
+      logger.info('Changed existing user recipe');
+    } else if (location == 'project' && _.has(recipes_user, recipe)) {
+      logger.info('Saved project recipe, overriding user');
+    } else if (location === 'project' && _.has(recipes_system, recipe)) {
+      logger.info('Saved project recipe, overriding built-in');
+    } else if (location === 'user' && _.has(recipes_system, recipe)) {
+      logger.info('Saved user recipe, overriding built-in');
+    } else {
+      logger.info('Saved ' + location + ' recipe');
+    }
   }
 
   if (location == 'project') {
@@ -135,10 +240,13 @@ function save(recipe, args, location) {
     clr = 'green';
   }
 
-  console.log();
-  console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+  if (!silent) {
+    console.log();
+    console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+    console.log();
+  }
 
-  console.log();
+  return { recipe, args, clr };
 }
 
 function remove(recipe, location) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -7,19 +7,27 @@ const { confirm } = require('@inquirer/prompts');
 
 const logger = require('./logger'),
   recipes = require('./recipes'),
+  simctl = require('./simctl'),
   utils = require('./utils'),
   chalk = require('chalk');
 
 exports.uninstall = uninstall;
 exports.generate = generate;
+exports.pruneOrphanRecipes = pruneOrphanRecipes;
 
 const PATH = path.resolve(__dirname, '..', 'hooks');
 
 function uninstall() {
   logger.info('Uninstalling the old 2.x Titanium CLI hook..\n');
 
-  spawn('ti', ['config', 'paths.hooks', '--remove', PATH], {
+  const proc = spawn('ti', ['config', 'paths.hooks', '--remove', PATH], {
     stdio: 'inherit',
+  });
+
+  // this runs as a postinstall script, where a missing Titanium CLI is a normal
+  // situation and must not fail the install with a stack trace
+  proc.on('error', () => {
+    logger.info('Titanium CLI not found, nothing to uninstall.');
   });
 }
 
@@ -38,13 +46,46 @@ function generate() {
     stderr += data;
   });
 
+  // spawn emits 'error' and then 'close' with a non-zero code for the same
+  // failure; reporting both means two messages for one problem
+  let spawnFailed = false;
+
+  tiProcess.on('error', (err) => {
+    spawnFailed = true;
+
+    logger.error(
+      err.code === 'ENOENT'
+        ? 'Could not run ' + chalk.cyan('ti') + '. Is the Titanium CLI installed?'
+        : 'Could not run ' + chalk.cyan('ti') + ': ' + err.message
+    );
+  });
+
   tiProcess.on('close', async (code) => {
+    if (spawnFailed) {
+      return;
+    }
+
     if (code !== 0) {
       logger.error('Failed to read Titanium info: ' + JSON.stringify([code, stderr]));
     } else {
       console.log();
 
-      const config = JSON.parse(stdout);
+      // `ti info` exits 0 while printing something other than JSON often enough
+      // (a banner, a warning, an update notice) that parsing it blind crashes
+      // generate with a stack trace instead of a usable message.
+      let config;
+
+      try {
+        config = JSON.parse(stdout);
+      } catch (e) {
+        logger.error('Could not read the output of ' + chalk.cyan('ti info -o json') + '.');
+        logger.error(stdout.trim().split('\n')[0] || e.message);
+        return;
+      }
+      // ti info reports simulators whose runtime was uninstalled as if they still
+      // existed. simctl knows which ones are actually usable, so it wins here.
+      const devices = await simctl.getDevices();
+      const simctlUdids = devices ? simctl.activeUdids(devices) : null;
       const saved = [];
       const savedIds = new Set();
       const activeIosUdids = new Set();
@@ -53,11 +94,7 @@ function generate() {
       if (config.android) {
         if (config.android.emulators && config.android.emulators.length > 0) {
           config.android.emulators.forEach(function forEach(dev) {
-            const name = dev.name
-              .toLowerCase()
-              .replace(/\.+/g, '')
-              .replace(/[^a-z0-9]+/g, '-')
-              .replace(/-$/, '');
+            const name = androidName(dev.name);
             const emulatorId = dev.id || dev.name;
             const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
@@ -71,11 +108,7 @@ function generate() {
 
         if (config.android.devices && config.android.devices.length > 0) {
           config.android.devices.forEach(function forEach(dev) {
-            const name = dev.name
-              .toLowerCase()
-              .replace(/\.+/g, '')
-              .replace(/[^a-z0-9]+/g, '-')
-              .replace(/-$/, '');
+            const name = androidName(dev.name);
             const recipe = ['--android', '--device', '--device-id', dev.id];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
@@ -108,6 +141,7 @@ function generate() {
         if (config.ios.simulators) {
           let version;
           const versions = [];
+          const simsByVersion = {};
 
           // Ti 5.0 has a ios and watch object
           const iosSims = config.ios.simulators.ios
@@ -115,6 +149,18 @@ function generate() {
             : config.ios.simulators;
 
           for (version in iosSims) {
+            // ti info still lists simulators whose runtime was uninstalled (ghosts).
+            // Skip them or we would generate recipes that the orphan check below
+            // immediately flags for removal, on every run.
+            const sims = simctlUdids
+              ? iosSims[version].filter((dev) => simctlUdids.has(dev.udid))
+              : iosSims[version];
+
+            if (sims.length === 0) {
+              continue;
+            }
+
+            simsByVersion[version] = sims;
             versions.push(version);
           }
 
@@ -123,7 +169,7 @@ function generate() {
           versions.reverse();
 
           versions.forEach(function forEach(version) {
-            iosSims[version].forEach(function forEach(dev) {
+            simsByVersion[version].forEach(function forEach(dev) {
               if (savedIds.has(dev.udid)) return;
 
               let name = dev.name
@@ -160,29 +206,28 @@ function generate() {
         console.log();
       }
 
-      const simctlUdids = await getActiveIosUdidsFromSimctl();
-      const orphans = recipes.listOrphans(simctlUdids || activeIosUdids, activeAndroidIds);
+      // Only prune a platform whose inventory we actually managed to read. If ti info
+      // never reported the platform (SDK not configured, wrong OS) its "active" set is
+      // empty for the wrong reason, and every recipe would look orphaned.
+      const iosActive = simctlUdids || (config.ios && config.ios.simulators ? activeIosUdids : null);
+      const androidActive =
+        config.android && Array.isArray(config.android.emulators) ? activeAndroidIds : null;
 
-      if (orphans.length > 0) {
-        logger.info(
-          'Found ' + orphans.length + ' orphaned recipes (simulator or emulator no longer installed):'
-        );
-        orphans.forEach((name) => {
-          console.log('  ' + chalk.red(name));
-        });
+      await pruneOrphanRecipes(iosActive, androidActive);
+
+      // Ghost simulators are skipped above, so without this line they would be
+      // invisible: still on disk, never mentioned again.
+      const ghosts = simctl.ghosts(devices);
+
+      if (ghosts.length > 0) {
         console.log();
-
-        const shouldRemove = await confirm({
-          message: 'Remove these orphaned recipes?',
-          default: false,
-        });
-
-        if (shouldRemove) {
-          orphans.forEach((name) => recipes.remove(name, 'user', true));
-          logger.info('Removed ' + orphans.length + ' orphaned recipes.');
-        } else {
-          logger.info('Keeping orphaned recipes. Run again to clean up later.');
-        }
+        logger.warn(
+          ghosts.length + ' ghost simulators found — their runtime is no longer installed'
+        );
+        // aligned under the message, past the 8-character "[WARN]  " prefix
+        console.log(
+          '        Run  ' + chalk.cyan('tn clean') + '  to remove them and free up disk space.'
+        );
         console.log();
       }
 
@@ -191,37 +236,47 @@ function generate() {
   });
 }
 
-// ti info reports iOS simulators whose runtime was uninstalled (ghost sims) as if
-// they still existed. simctl exposes an `isAvailable` flag that ioslib explicitly
-// ignores ("cannot be trusted") but which today reflects reality on modern Xcode.
-// We use it as the source of truth for "active" UDIDs when computing orphans.
-// Returns null on any failure so the caller can fall back to the ti info set.
-function getActiveIosUdidsFromSimctl() {
-  return new Promise((resolve) => {
-    const proc = spawn('xcrun', ['simctl', 'list', 'devices', '--json'], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    let out = '';
-    proc.stdout.on('data', (data) => {
-      out += data;
-    });
-    proc.on('error', () => resolve(null));
-    proc.on('close', (code) => {
-      if (code !== 0) return resolve(null);
-      try {
-        const data = JSON.parse(out);
-        const udids = new Set();
-        Object.values(data.devices || {}).forEach((devs) => {
-          devs.forEach((dev) => {
-            if (dev.isAvailable === true && dev.udid) udids.add(dev.udid);
-          });
-        });
-        resolve(udids);
-      } catch (e) {
-        resolve(null);
-      }
-    });
+// Recipes pointing at a simulator or emulator that no longer exists. A null set
+// means that platform could not be inspected, in which case it is left alone.
+async function pruneOrphanRecipes(iosActive, androidActive) {
+  const orphans = recipes.listOrphans(iosActive, androidActive);
+
+  if (orphans.length === 0) {
+    return;
+  }
+
+  logger.info(
+    'Found ' + orphans.length + ' orphaned recipes (simulator or emulator no longer installed):'
+  );
+  orphans.forEach((name) => {
+    console.log('  ' + chalk.red(name));
   });
+  console.log();
+
+  const shouldRemove = await confirm({
+    message: 'Remove these orphaned recipes?',
+    default: false,
+  });
+
+  if (shouldRemove) {
+    orphans.forEach((name) => recipes.remove(name, 'user', true));
+    logger.info('Removed ' + orphans.length + ' orphaned recipes.');
+  } else {
+    logger.info('Keeping orphaned recipes. Run again to clean up later.');
+  }
+
+  console.log();
+}
+
+// "Pixel 8 Pro API 34." -> "pixel-8-pro-api-34". The iOS names below are built
+// slightly differently on purpose: changing either would rename the recipes
+// people already have saved.
+function androidName(name) {
+  return name
+    .toLowerCase()
+    .replace(/\.+/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-$/, '');
 }
 
 function arraysIdentical(a, b) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,7 +4,9 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const logger = require('./logger'),
-  recipes = require('./recipes');
+  recipes = require('./recipes'),
+  utils = require('./utils'),
+  chalk = require('chalk');
 
 exports.uninstall = uninstall;
 exports.generate = generate;
@@ -41,6 +43,8 @@ function generate() {
       console.log();
 
       const config = JSON.parse(stdout);
+      const saved = [];
+      const savedIds = new Set();
 
       if (config.android) {
         if (config.android.emulators && config.android.emulators.length > 0) {
@@ -54,7 +58,7 @@ function generate() {
             const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -69,7 +73,7 @@ function generate() {
             const recipe = ['--android', '--device', '--device-id', dev.id];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -90,7 +94,7 @@ function generate() {
             const recipe = ['--ios', '--device', '--device-id', dev.udid];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-              recipes.save(name, recipe);
+              saved.push(recipes.save(name, recipe, 'user', true));
             }
           });
         }
@@ -114,6 +118,8 @@ function generate() {
 
           versions.forEach(function forEach(version) {
             iosSims[version].forEach(function forEach(dev) {
+              if (savedIds.has(dev.udid)) return;
+
               let name = dev.name
                 .toLowerCase()
                 .replace(/[^a-z0-9]+/g, '-')
@@ -121,15 +127,29 @@ function generate() {
               const recipe = ['--ios', '--simulator', '--device-id', dev.udid];
 
               if (recipes.has(name) && versions[0] !== version) {
-                name = name + '-ios' + version.replace(/\./, '');
+                const existing = recipes.get(name);
+                const existingId = existing[existing.indexOf('--device-id') + 1];
+                if (existingId !== dev.udid) {
+                  name = name + '-ios' + version.replace(/\./, '');
+                }
               }
 
               if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
-                recipes.save(name, recipe);
+                saved.push(recipes.save(name, recipe, 'user', true));
               }
+              savedIds.add(dev.udid);
             });
           });
         }
+      }
+
+      if (saved.length === 0) {
+        logger.info('All recipes are up to date.');
+      } else {
+        saved.forEach(({ recipe, args, clr }) => {
+          console.log('  ' + recipe + ': ' + chalk[clr](utils.join(args)));
+        });
+        console.log();
       }
 
       logger.info('Done');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const { spawn } = require('child_process');
 
+const { confirm } = require('@inquirer/prompts');
+
 const logger = require('./logger'),
   recipes = require('./recipes'),
   utils = require('./utils'),
@@ -36,7 +38,7 @@ function generate() {
     stderr += data;
   });
 
-  tiProcess.on('close', (code) => {
+  tiProcess.on('close', async (code) => {
     if (code !== 0) {
       logger.error('Failed to read Titanium info: ' + JSON.stringify([code, stderr]));
     } else {
@@ -45,6 +47,8 @@ function generate() {
       const config = JSON.parse(stdout);
       const saved = [];
       const savedIds = new Set();
+      const activeIosUdids = new Set();
+      const activeAndroidIds = new Set();
 
       if (config.android) {
         if (config.android.emulators && config.android.emulators.length > 0) {
@@ -56,6 +60,8 @@ function generate() {
               .replace(/-$/, '');
             const emulatorId = dev.id || dev.name;
             const recipe = ['--android', '--emulator', '--device-id', emulatorId];
+
+            activeAndroidIds.add(emulatorId);
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
               saved.push(recipes.save(name, recipe, 'user', true));
@@ -126,6 +132,8 @@ function generate() {
                 .replace(/-$/, '');
               const recipe = ['--ios', '--simulator', '--device-id', dev.udid];
 
+              activeIosUdids.add(dev.udid);
+
               if (recipes.has(name) && versions[0] !== version) {
                 const existing = recipes.get(name);
                 const existingId = existing[existing.indexOf('--device-id') + 1];
@@ -152,8 +160,67 @@ function generate() {
         console.log();
       }
 
+      const simctlUdids = await getActiveIosUdidsFromSimctl();
+      const orphans = recipes.listOrphans(simctlUdids || activeIosUdids, activeAndroidIds);
+
+      if (orphans.length > 0) {
+        logger.info(
+          'Found ' + orphans.length + ' orphaned recipes (simulator or emulator no longer installed):'
+        );
+        orphans.forEach((name) => {
+          console.log('  ' + chalk.red(name));
+        });
+        console.log();
+
+        const shouldRemove = await confirm({
+          message: 'Remove these orphaned recipes?',
+          default: false,
+        });
+
+        if (shouldRemove) {
+          orphans.forEach((name) => recipes.remove(name, 'user', true));
+          logger.info('Removed ' + orphans.length + ' orphaned recipes.');
+        } else {
+          logger.info('Keeping orphaned recipes. Run again to clean up later.');
+        }
+        console.log();
+      }
+
       logger.info('Done');
     }
+  });
+}
+
+// ti info reports iOS simulators whose runtime was uninstalled (ghost sims) as if
+// they still existed. simctl exposes an `isAvailable` flag that ioslib explicitly
+// ignores ("cannot be trusted") but which today reflects reality on modern Xcode.
+// We use it as the source of truth for "active" UDIDs when computing orphans.
+// Returns null on any failure so the caller can fall back to the ti info set.
+function getActiveIosUdidsFromSimctl() {
+  return new Promise((resolve) => {
+    const proc = spawn('xcrun', ['simctl', 'list', 'devices', '--json'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let out = '';
+    proc.stdout.on('data', (data) => {
+      out += data;
+    });
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => {
+      if (code !== 0) return resolve(null);
+      try {
+        const data = JSON.parse(out);
+        const udids = new Set();
+        Object.values(data.devices || {}).forEach((devs) => {
+          devs.forEach((dev) => {
+            if (dev.isAvailable === true && dev.udid) udids.add(dev.udid);
+          });
+        });
+        resolve(udids);
+      } catch (e) {
+        resolve(null);
+      }
+    });
   });
 }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -50,7 +50,8 @@ function generate() {
               .replace(/\.+/g, '')
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/-$/, '');
-            const recipe = ['--android', '--emulator', '--device-id', dev.name];
+            const emulatorId = dev.id || dev.name;
+            const recipe = ['--android', '--emulator', '--device-id', emulatorId];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
               recipes.save(name, recipe);

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -1,0 +1,127 @@
+// Thin wrapper around `xcrun simctl`.
+//
+// Every lookup resolves to null on any failure (no Xcode, not macOS, unreadable
+// JSON) instead of throwing, so each caller decides what "we could not find out"
+// means for it. That distinction matters: an empty list means "nothing is
+// installed", null means "we have no idea", and treating the second as the first
+// is how you end up offering to delete recipes that are perfectly fine.
+
+const { spawn } = require('child_process');
+
+exports.exec = exec;
+exports.getDevices = getDevices;
+exports.getRuntimes = getRuntimes;
+exports.activeUdids = activeUdids;
+exports.ghosts = ghosts;
+
+function exec(args) {
+  return new Promise(resolve => {
+    const proc = spawn('xcrun', ['simctl'].concat(args), {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', data => {
+      stdout += data;
+    });
+
+    proc.stderr.on('data', data => {
+      stderr += data;
+    });
+
+    proc.on('error', () => resolve({ code: -1, stdout: '', stderr: 'xcrun not found' }));
+    proc.on('close', code => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function json(args) {
+  const res = await exec(args.concat(['--json']));
+
+  if (res.code !== 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(res.stdout);
+  } catch (e) {
+    return null;
+  }
+}
+
+// Flattens the runtime-keyed device map into a single list. Returns null if
+// simctl could not be queried.
+async function getDevices() {
+  const data = await json(['list', 'devices']);
+
+  if (!data || !data.devices) {
+    return null;
+  }
+
+  const devices = [];
+
+  Object.keys(data.devices).forEach(runtime => {
+    data.devices[runtime].forEach(dev => {
+      devices.push({
+        udid: dev.udid,
+        name: dev.name,
+        state: dev.state,
+        // ioslib ignores isAvailable ("cannot be trusted") but on modern Xcode it
+        // is what tells a real simulator apart from one whose runtime was removed.
+        isAvailable: dev.isAvailable === true,
+        dataPath: dev.dataPath,
+        runtime: runtimeLabel(runtime),
+      });
+    });
+  });
+
+  return devices;
+}
+
+async function getRuntimes() {
+  const data = await json(['runtime', 'list']);
+
+  if (!data) {
+    return null;
+  }
+
+  return Object.keys(data).map(id => {
+    const rt = data[id];
+
+    return {
+      id: id,
+      version: rt.version,
+      build: rt.build,
+      platform: rt.platformIdentifier,
+      name: runtimeLabel(rt.runtimeIdentifier || id),
+      sizeBytes: rt.sizeBytes,
+      lastUsedAt: rt.lastUsedAt,
+      deletable: rt.deletable !== false,
+    };
+  });
+}
+
+function activeUdids(devices) {
+  const udids = new Set();
+
+  (devices || []).forEach(dev => {
+    if (dev.isAvailable) {
+      udids.add(dev.udid);
+    }
+  });
+
+  return udids;
+}
+
+function ghosts(devices) {
+  return (devices || []).filter(dev => !dev.isAvailable);
+}
+
+// com.apple.CoreSimulator.SimRuntime.iOS-26-4 -> iOS 26.4
+function runtimeLabel(identifier) {
+  const tail = String(identifier).split('.').pop();
+  const parts = tail.match(/^([A-Za-z]+)-(.+)$/);
+
+  return parts ? parts[1] + ' ' + parts[2].replace(/-/g, '.') : identifier;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tn",
-  "version": "5.0.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tn",
-      "version": "5.0.0",
+      "version": "5.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "5.2.0",
+  "version": "5.3.0",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"

--- a/tn.json
+++ b/tn.json
@@ -29,7 +29,7 @@
 
 	"desktop": ["-output-dir", "~/Desktop"],
 
-	"key-password": ["--key-password", "%s", "--key-password", "%s", "--platform", "android"],
+	"key-password": ["--key-password", "%s", "--platform", "android"],
 	"android-sdk": ["--android-sdk", "%s", "--platform", "android"],
 	"avd-abi": ["--avd-abi", "%s", "--platform", "android"],
 	"keystore": ["--keystore", "%s", "--platform", "android"],

--- a/tn.json
+++ b/tn.json
@@ -29,11 +29,6 @@
 
 	"desktop": ["-output-dir", "~/Desktop"],
 
-	"ip18": ["--sim-version", "18.6", "--sim-type", "iphone"],
-	"ip26": ["--sim-version", "26.1", "--sim-type", "iphone"],
-	"ipad18": ["--sim-version", "18.6", "--sim-type", "ipad"],
-	"ipad26": ["--sim-version", "26.1", "--sim-type", "ipad"],
-
 	"key-password": ["--key-password", "%s", "--key-password", "%s", "--platform", "android"],
 	"android-sdk": ["--android-sdk", "%s", "--platform", "android"],
 	"avd-abi": ["--avd-abi", "%s", "--platform", "android"],


### PR DESCRIPTION
This replaces #60 and #61, which I've closed. Every commit from both is already contained here, so this is now the single PR for all of it: one review, one merge, no ordering to keep track of.

## What's in here

**`tn clean` (new command)**

Xcode leaves simulators behind when you uninstall a runtime. They still show up in `simctl list`, can never be booted again, and sit there forever — on my machine that was 11 simulators and 14.2 GB. `tn clean` removes them. `--data` erases contents and settings while keeping the simulators, `--runtimes` deletes runtimes you pick from a list with sizes and last-use dates. Everything lists what it found, reports the space it frees, and asks first, defaulting to no. Android is untouched.

**`tn generate` no longer loops on ghost simulators**

`ti info` reports simulators whose runtime is gone as if they still existed, so `generate` recreated a recipe for each one and the orphan check immediately flagged them for removal — every single run, forever. The `simctl` check that was already used to detect orphans is now applied when generating too.

**`tn generate` no longer offers to delete recipes for a platform it couldn't inspect**

If `ti info` didn't report a platform at all (an unconfigured Android SDK, for instance), its device list came back empty and every recipe for that platform looked orphaned. An empty list now means "nothing installed" only when the platform was actually inspected.

**Robustness fixes**

A malformed `~/.tn.json` took down every command with a stack trace, leaving no way to even run `tn list` and find the typo. `generate` crashed when `ti info` returned something that wasn't JSON, and when the Titanium CLI was missing — which also broke the `postinstall` script. `tn rename` rebuilt its recipe list without project recipes, dropping them until the next run.

**Grouped `tn list` output and README overhaul** (was #61)

`tn list` groups recipes into labeled categories, `tn generate` no longer creates duplicate `-iosXXX` recipes on repeated runs, and the README tables were restructured to match.

**Android emulator recipes use the AVD id** (was #60)

**Output cleanup**

Informational messages print without an `[INFO]` label — when every line carries one it stops meaning anything, and it made warnings and errors blend in. `[WARN]`, `[ERROR]` and `[DEBUG]` keep theirs.

## Reviewing this

The commits are semantic and self-contained, so the diff reads better commit by commit than as a whole. Nothing here changes the name of any generated recipe — I checked that specifically, since renaming them would break recipes people already have saved.

There are no tests in the repo, so I verified the destructive paths against a stubbed `simctl` with mutable state: deleting ghosts, deleting a runtime and sweeping the simulators it orphans, erasing data while skipping booted simulators, and the cases where Xcode or the Titanium CLI are missing. ESLint is clean.

## On the version bump

The last commit bumps to 5.4.0 and promotes the CHANGELOG. Versioning your project is your call, so say the word and I'll drop that commit and leave the release to you.
